### PR TITLE
Track time to reach target accuracy

### DIFF
--- a/customCriptografy/benchmark.py
+++ b/customCriptografy/benchmark.py
@@ -1,0 +1,135 @@
+"""Utilities to measure end-to-end encryption scenario runtimes.
+
+This module provides a small timing harness that can be used to wrap any
+encryption workflow and capture the wall-clock time for the entire process.
+It is intentionally dependency-free so it can be dropped into existing
+experiments without extra requirements.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from time import perf_counter
+from typing import Any, Callable, Iterable, List, Mapping, Tuple
+
+
+# Public data structures ---------------------------------------------------------------------------
+
+
+@dataclass
+class ScenarioResult:
+    """Container for a single scenario execution."""
+
+    name: str
+    duration_seconds: float
+    output: Any
+
+
+# Timing helpers ------------------------------------------------------------------------------------
+
+
+def time_call(name: str, func: Callable[..., Any], *args: Any, **kwargs: Any) -> ScenarioResult:
+    """Execute ``func`` while measuring its wall-clock duration.
+
+    Parameters
+    ----------
+    name:
+        Descriptive name for the scenario. This is used only for reporting.
+    func:
+        Callable representing the encryption scenario to execute.
+    *args, **kwargs:
+        Positional and keyword arguments forwarded to ``func``.
+
+    Returns
+    -------
+    ScenarioResult
+        Object containing the scenario name, duration in seconds, and the return
+        value produced by ``func``.
+    """
+
+    start = perf_counter()
+    output = func(*args, **kwargs)
+    duration_seconds = perf_counter() - start
+    return ScenarioResult(name=name, duration_seconds=duration_seconds, output=output)
+
+
+def run_suite(
+    scenarios: Mapping[str, Callable[[], Any]] | Iterable[Tuple[str, Callable[[], Any]]]
+) -> Tuple[List[ScenarioResult], float]:
+    """Run multiple scenarios while tracking individual and total duration.
+
+    The function accepts either a mapping (preserving insertion order) or an
+    iterable of ``(name, callable)`` pairs. The suite runtime measures the entire
+    process from the first scenario invocation to the completion of the last one.
+
+    Parameters
+    ----------
+    scenarios:
+        Encryption scenarios keyed by a human-readable name.
+
+    Returns
+    -------
+    Tuple[List[ScenarioResult], float]
+        A list of per-scenario results paired with the overall wall-clock time
+        (in seconds) needed to run the entire suite.
+    """
+
+    ordered: List[Tuple[str, Callable[[], Any]]]
+    if isinstance(scenarios, Mapping):
+        ordered = list(scenarios.items())
+    else:
+        ordered = list(scenarios)
+
+    suite_start = perf_counter()
+    results = [time_call(name, fn) for name, fn in ordered]
+    total_duration = perf_counter() - suite_start
+    return results, total_duration
+
+
+# Example usage ------------------------------------------------------------------------------------
+
+
+def _xor_cipher(payload: bytes, key: bytes) -> bytes:
+    """Very small XOR-based cipher used only for demonstration.
+
+    This is intentionally simple and **not** intended for production use. It
+    allows us to exercise the timing harness without external dependencies.
+    """
+
+    return bytes(b ^ key[i % len(key)] for i, b in enumerate(payload))
+
+
+def example_scenarios() -> List[Tuple[str, Callable[[], Any]]]:
+    """Build lightweight example scenarios for manual testing.
+
+    Returns
+    -------
+    List[Tuple[str, Callable[[], Any]]]
+        Ready-to-run scenarios demonstrating how to plug encryption workflows
+        into :func:`run_suite`.
+    """
+
+    payload = b"Secret payload to encrypt multiple times for timing."
+    key_a = b"key-a"
+    key_b = b"key-b"
+
+    return [
+        (
+            "xor-single-pass",
+            lambda: _xor_cipher(payload, key_a),
+        ),
+        (
+            "xor-double-pass",
+            lambda: _xor_cipher(_xor_cipher(payload, key_a), key_b),
+        ),
+    ]
+
+
+if __name__ == "__main__":
+    scenarios = example_scenarios()
+    results, total = run_suite(scenarios)
+
+    print("Scenario timing summary:\n")
+    for result in results:
+        print(f"- {result.name}: {result.duration_seconds:.6f}s")
+    print(f"\nTempo totale esecuzione suite: {total:.6f}s")

--- a/framework/py/flwr/server/history.py
+++ b/framework/py/flwr/server/history.py
@@ -17,6 +17,7 @@
 
 import pprint
 from functools import reduce
+from typing import Optional
 
 from flwr.common.typing import Scalar
 
@@ -30,6 +31,7 @@ class History:
         self.metrics_distributed_fit: dict[str, list[tuple[int, Scalar]]] = {}
         self.metrics_distributed: dict[str, list[tuple[int, Scalar]]] = {}
         self.metrics_centralized: dict[str, list[tuple[int, Scalar]]] = {}
+        self.time_to_target_accuracy: Optional[float] = None
 
     def add_loss_distributed(self, server_round: int, loss: float) -> None:
         """Add one loss entry (from distributed evaluation)."""
@@ -120,5 +122,10 @@ class History:
         if self.metrics_centralized:
             rep += "History (metrics, centralized):\n" + pprint.pformat(
                 self.metrics_centralized
+            )
+        if self.time_to_target_accuracy is not None:
+            rep += (
+                "\nTime to target accuracy: "
+                f"{self.time_to_target_accuracy:.2f}s"
             )
         return rep

--- a/framework/py/flwr/server/server.py
+++ b/framework/py/flwr/server/server.py
@@ -84,9 +84,49 @@ class Server:
         return self._client_manager
 
     # pylint: disable=too-many-locals
-    def fit(self, num_rounds: int, timeout: Optional[float]) -> tuple[History, float]:
-        """Run federated averaging for a number of rounds."""
+    def fit(
+        self,
+        num_rounds: int,
+        timeout: Optional[float],
+        target_accuracy: Optional[float] = None,
+        target_accuracy_key: str = "accuracy",
+    ) -> tuple[History, float]:
+        """Run federated averaging for a number of rounds.
+
+        Parameters
+        ----------
+        num_rounds : int
+            Total number of rounds to run.
+        timeout : Optional[float]
+            Timeout value forwarded to client instructions.
+        target_accuracy : Optional[float]
+            If provided, wall-clock time will be captured the first time the
+            aggregated metrics include ``target_accuracy_key`` meeting or
+            exceeding this value.
+        target_accuracy_key : str
+            Metric key to inspect for the target accuracy threshold.
+        """
+
         history = History()
+
+        start_time = timeit.default_timer()
+        time_to_target: Optional[float] = None
+
+        def maybe_set_time_to_target(metrics: dict[str, Scalar]) -> None:
+            nonlocal time_to_target
+            if target_accuracy is None or time_to_target is not None:
+                return
+            metric_value = metrics.get(target_accuracy_key)
+            if metric_value is None:
+                return
+
+            try:
+                numeric_value = float(metric_value)
+            except (TypeError, ValueError):
+                return
+
+            if numeric_value >= target_accuracy:
+                time_to_target = timeit.default_timer() - start_time
 
         # Initialize parameters
         log(INFO, "[INIT]")
@@ -102,11 +142,11 @@ class Server:
             )
             history.add_loss_centralized(server_round=0, loss=res[0])
             history.add_metrics_centralized(server_round=0, metrics=res[1])
+            maybe_set_time_to_target(res[1])
         else:
             log(INFO, "Evaluation returned no results (`None`)")
 
         # Run federated learning for num_rounds
-        start_time = timeit.default_timer()
 
         for current_round in range(1, num_rounds + 1):
             log(INFO, "")
@@ -140,6 +180,7 @@ class Server:
                 history.add_metrics_centralized(
                     server_round=current_round, metrics=metrics_cen
                 )
+                maybe_set_time_to_target(metrics_cen)
 
             # Evaluate model on a sample of available clients
             res_fed = self.evaluate_round(server_round=current_round, timeout=timeout)
@@ -152,10 +193,12 @@ class Server:
                     history.add_metrics_distributed(
                         server_round=current_round, metrics=evaluate_metrics_fed
                     )
+                    maybe_set_time_to_target(evaluate_metrics_fed)
 
         # Bookkeeping
         end_time = timeit.default_timer()
         elapsed = end_time - start_time
+        history.time_to_target_accuracy = time_to_target
         return history, elapsed
 
     def evaluate_round(
@@ -490,12 +533,23 @@ def run_fl(
 ) -> History:
     """Train a model on the given server and return the History object."""
     hist, elapsed_time = server.fit(
-        num_rounds=config.num_rounds, timeout=config.round_timeout
+        num_rounds=config.num_rounds,
+        timeout=config.round_timeout,
+        target_accuracy=config.target_accuracy,
+        target_accuracy_key=config.target_accuracy_key,
     )
 
     log(INFO, "")
     log(INFO, "[SUMMARY]")
     log(INFO, "Run finished %s round(s) in %.2fs", config.num_rounds, elapsed_time)
+    if hist.time_to_target_accuracy is not None:
+        log(
+            INFO,
+            "Target accuracy reached in %.2fs (metric: %s, threshold: %s)",
+            hist.time_to_target_accuracy,
+            config.target_accuracy_key,
+            config.target_accuracy,
+        )
     for line in io.StringIO(str(hist)):
         log(INFO, "\t%s", line.strip("\n"))
     log(INFO, "")

--- a/framework/py/flwr/server/server_config.py
+++ b/framework/py/flwr/server/server_config.py
@@ -29,6 +29,8 @@ class ServerConfig:
 
     num_rounds: int = 1
     round_timeout: Optional[float] = None
+    target_accuracy: Optional[float] = None
+    target_accuracy_key: str = "accuracy"
 
     def __repr__(self) -> str:
         """Return the string representation of the ServerConfig."""
@@ -37,4 +39,12 @@ class ServerConfig:
             if self.round_timeout is None
             else f"round_timeout={self.round_timeout}s"
         )
-        return f"num_rounds={self.num_rounds}, {timeout_string}"
+        accuracy_string = (
+            "no target_accuracy"
+            if self.target_accuracy is None
+            else f"target_accuracy={self.target_accuracy} ({self.target_accuracy_key})"
+        )
+        return (
+            f"num_rounds={self.num_rounds}, {timeout_string}, "
+            f"{accuracy_string}"
+        )


### PR DESCRIPTION
## Summary
- add target accuracy configuration to ServerConfig and propagate into server runs
- track wall-clock time to first threshold hit in Server.fit and store it in History for reporting
- log the time-to-accuracy alongside existing training summaries

## Testing
- python -m compileall framework/py/flwr/server

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6920a386ae3483328833972e97ecc34c)