### PR TITLE
Add AES‑GCM message crypto module and runtime‑selectable encryption in ClientApp

### DIFF
--- a/framework/py/flwr/common/crypto/__init__.py
+++ b/framework/py/flwr/common/crypto/__init__.py
@@ -1,0 +1,16 @@
+# Copyright 2025 Flower Labs GmbH. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""Crypto utilities for message transport."""
+

--- a/framework/py/flwr/common/crypto/aes_gcm.py
+++ b/framework/py/flwr/common/crypto/aes_gcm.py
@@ -1,0 +1,44 @@
+# Copyright 2025 Flower Labs GmbH. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""AES-GCM implementation for message crypto."""
+
+from __future__ import annotations
+
+import os
+
+from cryptography.hazmat.primitives.ciphers.aead import AESGCM
+
+_AES_GCM_NONCE_SIZE = 12
+
+
+class AesGcmCrypto:
+    """AES-GCM crypto implementation with random IV."""
+
+    def __init__(self, key: bytes) -> None:
+        self._aesgcm = AESGCM(key)
+
+    def encrypt(self, plaintext: bytes) -> bytes:
+        """Encrypt plaintext bytes."""
+        nonce = os.urandom(_AES_GCM_NONCE_SIZE)
+        ciphertext = self._aesgcm.encrypt(nonce, plaintext, None)
+        return nonce + ciphertext
+
+    def decrypt(self, ciphertext: bytes) -> bytes:
+        """Decrypt ciphertext bytes."""
+        if len(ciphertext) <= _AES_GCM_NONCE_SIZE:
+            raise ValueError("Ciphertext is too short for AES-GCM payload.")
+        nonce = ciphertext[:_AES_GCM_NONCE_SIZE]
+        payload = ciphertext[_AES_GCM_NONCE_SIZE:]
+        return self._aesgcm.decrypt(nonce, payload, None)

--- a/framework/py/flwr/common/crypto/message_crypto.py
+++ b/framework/py/flwr/common/crypto/message_crypto.py
@@ -1,0 +1,62 @@
+# Copyright 2025 Flower Labs GmbH. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""Message crypto utilities."""
+
+from __future__ import annotations
+
+import base64
+import binascii
+from typing import Protocol
+
+from .aes_gcm import AesGcmCrypto
+
+
+class MessageCrypto(Protocol):
+    """Protocol for message encryption/decryption."""
+
+    def encrypt(self, plaintext: bytes) -> bytes:
+        """Encrypt plaintext bytes."""
+
+    def decrypt(self, ciphertext: bytes) -> bytes:
+        """Decrypt ciphertext bytes."""
+
+
+class NoopCrypto:
+    """No-op crypto implementation."""
+
+    def encrypt(self, plaintext: bytes) -> bytes:
+        """Return plaintext as-is."""
+        return plaintext
+
+    def decrypt(self, ciphertext: bytes) -> bytes:
+        """Return ciphertext as-is."""
+        return ciphertext
+
+
+def get_message_crypto(config: dict) -> MessageCrypto:
+    """Return MessageCrypto based on configuration."""
+    crypto_type = str(config.get("type", "none")).lower()
+    if crypto_type in {"none", "noop"}:
+        return NoopCrypto()
+    if crypto_type == "aes":
+        key_b64 = config.get("key")
+        if not key_b64:
+            raise ValueError("AES message crypto requires a base64 key.")
+        try:
+            key = base64.b64decode(key_b64, validate=True)
+        except (ValueError, binascii.Error) as err:
+            raise ValueError("Invalid base64 key for AES message crypto.") from err
+        return AesGcmCrypto(key)
+    raise ValueError(f"Unsupported message crypto type: {crypto_type}")

--- a/framework/py/flwr/common/crypto/message_crypto_test.py
+++ b/framework/py/flwr/common/crypto/message_crypto_test.py
@@ -1,0 +1,48 @@
+# Copyright 2025 Flower Labs GmbH. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""Tests for message crypto."""
+
+import base64
+import os
+
+import pytest
+
+from .message_crypto import get_message_crypto
+
+
+def test_aes_gcm_roundtrip() -> None:
+    """Test AES-GCM encryption/decryption roundtrip."""
+    key = base64.b64encode(os.urandom(32)).decode("utf-8")
+    crypto = get_message_crypto({"type": "aes", "key": key})
+    plaintext = b"flower-crypto"
+    ciphertext = crypto.encrypt(plaintext)
+
+    assert ciphertext != plaintext
+    assert crypto.decrypt(ciphertext) == plaintext
+
+
+def test_noop_crypto_no_change() -> None:
+    """Test noop mode does not modify bytes."""
+    crypto = get_message_crypto({"type": "none"})
+    plaintext = b"noop"
+
+    assert crypto.encrypt(plaintext) == plaintext
+    assert crypto.decrypt(plaintext) == plaintext
+
+
+def test_aes_gcm_missing_key_raises() -> None:
+    """Test missing AES key raises error."""
+    with pytest.raises(ValueError, match="base64 key"):
+        get_message_crypto({"type": "aes"})

--- a/framework/py/flwr/supernode/runtime/run_clientapp.py
+++ b/framework/py/flwr/supernode/runtime/run_clientapp.py
@@ -15,9 +15,11 @@
 """Flower ClientApp process."""
 
 
+from collections.abc import Iterable
 from logging import DEBUG, ERROR, INFO
 
 import grpc
+import os
 
 from flwr.app.error import Error
 from flwr.cli.install import install_from_fab
@@ -31,6 +33,7 @@ from flwr.common.grpc import create_channel, on_channel_state_change
 from flwr.common.inflatable import (
     get_all_nested_objects,
     get_object_tree,
+    iterate_object_tree,
     no_object_id_recompute,
 )
 from flwr.common.inflatable_protobuf_utils import (
@@ -38,7 +41,12 @@ from flwr.common.inflatable_protobuf_utils import (
     make_pull_object_fn_protobuf,
     make_push_object_fn_protobuf,
 )
-from flwr.common.inflatable_utils import pull_and_inflate_object_from_tree, push_objects
+from flwr.common.inflatable_utils import (
+    inflate_object_from_contents,
+    pull_objects,
+    push_object_contents_from_iterable,
+)
+from flwr.common.crypto.message_crypto import get_message_crypto
 from flwr.common.logger import log
 from flwr.common.message import remove_content_from_message
 from flwr.common.retry_invoker import _make_simple_grpc_retry_invoker, _wrap_stub
@@ -187,14 +195,36 @@ def pull_clientappinputs(
         run_id = context.run_id
         node = Node(node_id=context.node_id)
         object_tree = pull_msg_res.message_object_trees[0]
-        message = pull_and_inflate_object_from_tree(
-            object_tree,
-            make_pull_object_fn_protobuf(stub.PullObject, node, run_id),
-            make_confirm_message_received_fn_protobuf(
-                stub.ConfirmMessageReceived, node, run_id
-            ),
-            return_type=Message,
+        crypto_type = context.run_config.get("message-crypto") or os.environ.get(
+            "FLWR_MESSAGE_CRYPTO"
         )
+        crypto_key = context.run_config.get("message-crypto-key") or os.environ.get(
+            "FLWR_MESSAGE_CRYPTO_KEY"
+        )
+        message_crypto = get_message_crypto(
+            {"type": crypto_type or "none", "key": crypto_key}
+        )
+
+        pulled_object_contents = pull_objects(
+            [tree.object_id for tree in iterate_object_tree(object_tree)],
+            make_pull_object_fn_protobuf(stub.PullObject, node, run_id),
+        )
+        decrypted_object_contents = {
+            obj_id: message_crypto.decrypt(content)
+            for obj_id, content in pulled_object_contents.items()
+        }
+        make_confirm_message_received_fn_protobuf(
+            stub.ConfirmMessageReceived, node, run_id
+        )(object_tree.object_id)
+        message = inflate_object_from_contents(
+            object_tree.object_id,
+            decrypted_object_contents,
+            keep_object_contents=False,
+        )
+        if not isinstance(message, Message):
+            raise TypeError(
+                f"Expected object of type Message, but got {type(message).__name__}."
+            )
 
         # Set the message ID
         # The deflated message doesn't contain the message_id (its own object_id)
@@ -236,17 +266,34 @@ def push_clientappoutputs(
             # Retrieve the object IDs to push
             object_ids_to_push = set(push_msg_res.objects_to_push)
 
+            crypto_type = context.run_config.get("message-crypto") or os.environ.get(
+                "FLWR_MESSAGE_CRYPTO"
+            )
+            crypto_key = context.run_config.get("message-crypto-key") or os.environ.get(
+                "FLWR_MESSAGE_CRYPTO_KEY"
+            )
+            message_crypto = get_message_crypto(
+                {"type": crypto_type or "none", "key": crypto_key}
+            )
+
             # Push all objects
             all_objects = get_all_nested_objects(message)
             del message
-            push_objects(
-                all_objects,
+            def iter_object_contents() -> Iterable[tuple[str, bytes]]:
+                for obj_id in list(all_objects.keys()):
+                    if obj_id not in object_ids_to_push:
+                        continue
+                    obj = all_objects[obj_id]
+                    del all_objects[obj_id]
+                    yield obj_id, message_crypto.encrypt(obj.deflate())
+
+            push_object_contents_from_iterable(
+                iter_object_contents(),
                 make_push_object_fn_protobuf(
                     stub.PushObject,
                     Node(node_id=context.node_id),
                     run_id=context.run_id,
                 ),
-                object_ids_to_push=object_ids_to_push,
             )
 
         # Push Context


### PR DESCRIPTION
### Motivation
- Protect object contents exchanged between ClientApp and SuperNode with an optional transport-layer encryption.
- Allow runtime selection of encryption mode and key via `context.run_config` or environment variables for flexible deployment.
- Isolate AES‑GCM implementation into its own module to keep concerns separated and make the cipher reusable.

### Description
- Add `flwr.common.crypto.aes_gcm` implementing `AesGcmCrypto` (random 12‑byte nonce + tag) and add `flwr.common.crypto.message_crypto` that exposes `MessageCrypto` (Protocol), `NoopCrypto`, and `get_message_crypto` selector that accepts a base64 key.
- Integrate crypto in `push_clientappoutputs` to encrypt deflated object bytes before pushing, and in `pull_clientappinputs` to decrypt pulled object bytes before inflating; selection uses `context.run_config["message-crypto"]` or `FLWR_MESSAGE_CRYPTO` and key from `context.run_config["message-crypto-key"]` or `FLWR_MESSAGE_CRYPTO_KEY`.
- Use `push_object_contents_from_iterable` / `pull_objects` / `inflate_object_from_contents` helpers to stream encrypted contents and limit to objects listed by the server.
- Add unit tests at `framework/py/flwr/common/crypto/message_crypto_test.py` covering AES‑GCM encrypt/decrypt roundtrip, `none` (noop) behavior, and missing AES key error handling.

### Testing
- Added unit tests for the message crypto primitives in `message_crypto_test.py` (not executed here).
- Code compiles and project files were committed locally, but an automated test suite (`pytest`) was not run as part of this change.
- No runtime integration tests were executed in CI as part of this PR.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6946ec071e048332aba2d177f4ef88b3)