### PR TITLE
Add Koblitz small/medium/large curve options

### DIFF
--- a/framework/py/flwr/common/crypto/algorithms/KOBLITZ.py
+++ b/framework/py/flwr/common/crypto/algorithms/KOBLITZ.py
@@ -26,6 +26,9 @@ SUPPORTED_CURVES: Dict[str, KoblitzCurve] = {
     "KOBLITZ_112": KoblitzCurve("KOBLITZ_112", 112),
     "KOBLITZ_256": KoblitzCurve("KOBLITZ_256", 256),
     "KOBLITZ_512": KoblitzCurve("KOBLITZ_512", 512),
+    "KOBLITZ_SMALL": KoblitzCurve("KOBLITZ_SMALL", 112),
+    "KOBLITZ_MEDIUM": KoblitzCurve("KOBLITZ_MEDIUM", 256),
+    "KOBLITZ_LARGE": KoblitzCurve("KOBLITZ_LARGE", 512),
 }
 
 

--- a/framework/py/flwr/common/crypto/start.py
+++ b/framework/py/flwr/common/crypto/start.py
@@ -10,9 +10,9 @@ ENCRYPTION_METHODS = [
     "CHACHA",
     "CHACHA_AEAD",
     "AES_GCM",
-    "KOBLITZ_112",
-    "KOBLITZ_256",
-    "KOBLITZ_512",
+    "KOBLITZ_SMALL",
+    "KOBLITZ_MEDIUM",
+    "KOBLITZ_LARGE",
 ]
 INTEGRITY_METHODS = ["HMAC"]
 NET_OPTIONS = ["custom_cnn", "resnet18", "resnet34", "tiny_cnn", "squeezenet"]


### PR DESCRIPTION
### Motivation
- Esporre alias più leggibili per le curve Koblitz (`small`/`medium`/`large`) mappati su 112/256/512 bit per semplificare la scelta del metodo di crittografia.

### Description
- Aggiunte le chiavi `KOBLITZ_SMALL`, `KOBLITZ_MEDIUM` e `KOBLITZ_LARGE` in `framework/py/flwr/common/crypto/algorithms/KOBLITZ.py` (rispettivamente 112/256/512 bit) e aggiornate le opzioni `ENCRYPTION_METHODS` in `framework/py/flwr/common/crypto/start.py` per esporre i nuovi alias nel prompt di configurazione.

### Testing
- Non sono stati eseguiti test automatici su queste modifiche.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696fdfa146f483328c93b4c47ecca424)