### PR TITLE
Generate detailed crypto PDF reports on accuracy threshold

### DIFF
--- a/framework/py/flwr/common/crypto/log_file.py
+++ b/framework/py/flwr/common/crypto/log_file.py
@@ -67,7 +67,13 @@ def add_crypto_time(duration: float) -> None:
     global ROUND_CRYPTO_TIME
     ROUND_CRYPTO_TIME += duration
 
-def finalize_round_timing(round_number: int, round_elapsed: float) -> Dict[str, float]:
+def finalize_round_timing(
+    round_number: int,
+    round_elapsed: float,
+    *,
+    accuracy_centralized: float | None = None,
+    accuracy_federated: float | None = None,
+) -> Dict[str, float]:
     without_crypto = max(round_elapsed - ROUND_CRYPTO_TIME, 0.0)
     summary = {
         "round": float(round_number),
@@ -75,6 +81,10 @@ def finalize_round_timing(round_number: int, round_elapsed: float) -> Dict[str, 
         "crypto_time": ROUND_CRYPTO_TIME,
         "without_crypto": without_crypto,
     }
+    if accuracy_centralized is not None:
+        summary["accuracy_centralized"] = accuracy_centralized
+    if accuracy_federated is not None:
+        summary["accuracy_federated"] = accuracy_federated
     ROUND_SUMMARIES.append(summary)
     return summary
 
@@ -143,13 +153,47 @@ def generate_report_pdf(path: str = "crypto_report.pdf") -> str:
     if not ROUND_SUMMARIES:
         lines = ["Nessun dato di round disponibile."]
     else:
-        first = ROUND_SUMMARIES[0]
         total_time = sum(item["round_time"] for item in ROUND_SUMMARIES)
+        total_crypto = sum(item["crypto_time"] for item in ROUND_SUMMARIES)
+        total_without = sum(item["without_crypto"] for item in ROUND_SUMMARIES)
+        total_impact = (total_crypto / total_time * 100.0) if total_time > 0 else 0.0
+        encryption_info = (
+            f"Crittografia: {ENCRYPTION_METHOD}"
+            if ENCRYPTION_ENABLED
+            else "Crittografia: disabilitata"
+        )
         lines = [
-            f"Primo round: tempo={first['round_time']:.2f}s, senza critto={first['without_crypto']:.2f}s",
-            f"Tempo totale: {total_time:.2f}s",
+            "Report risultati crittografia",
+            encryption_info,
+            f"Round totali: {len(ROUND_SUMMARIES)}",
+            (
+                "Tempo totale: "
+                f"{total_time:.2f}s | critto={total_crypto:.2f}s "
+                f"| senza_critto={total_without:.2f}s | impatto={total_impact:.1f}%"
+            ),
             f"Generato: {datetime.now().isoformat(timespec='seconds')}",
+            "Dettaglio round:",
         ]
+        for item in ROUND_SUMMARIES:
+            impact = (
+                item["crypto_time"] / item["round_time"] * 100.0
+                if item["round_time"] > 0
+                else 0.0
+            )
+            line = (
+                f"- Round {int(item['round'])}: totale={item['round_time']:.2f}s "
+                f"| critto={item['crypto_time']:.2f}s "
+                f"| senza_critto={item['without_crypto']:.2f}s "
+                f"| impatto={impact:.1f}%"
+            )
+            accuracy_parts = []
+            if "accuracy_centralized" in item:
+                accuracy_parts.append(f"acc_cen={item['accuracy_centralized']:.4f}")
+            if "accuracy_federated" in item:
+                accuracy_parts.append(f"acc_fed={item['accuracy_federated']:.4f}")
+            if accuracy_parts:
+                line = f"{line} | " + " ".join(accuracy_parts)
+            lines.append(line)
     _write_simple_pdf(path, lines)
     REPORT_GENERATED = True
     return path

--- a/framework/py/flwr/server/server.py
+++ b/framework/py/flwr/server/server.py
@@ -138,6 +138,7 @@ class Server:
 
             # Evaluate model using strategy implementation
             res_cen = self.strategy.evaluate(current_round, parameters=self.parameters)
+            accuracy_centralized: Optional[float] = None
             if res_cen is not None:
                 loss_cen, metrics_cen = res_cen
                 log(INFO, "fit progress: (%s, %s, %s, %s)",
@@ -149,21 +150,29 @@ class Server:
                 )
                 print("metrics_cen",metrics_cen )
                 if "accuracy" in metrics_cen:
+                    accuracy_centralized = float(metrics_cen["accuracy"])
                     log_time("Round %s Accuracy (centralized): %.4f", current_round, metrics_cen["accuracy"])
 
             # Evaluate model on a sample of available clients
             res_fed = self.evaluate_round(server_round=current_round, timeout=timeout)
+            accuracy_federated: Optional[float] = None
             if res_fed is not None:
                 loss_fed, evaluate_metrics_fed, _ = res_fed
                 if loss_fed is not None:
                     history.add_loss_distributed(server_round=current_round, loss=loss_fed)
                     history.add_metrics_distributed(server_round=current_round, metrics=evaluate_metrics_fed)
                     if "accuracy" in evaluate_metrics_fed:
+                       accuracy_federated = float(evaluate_metrics_fed["accuracy"])
                        log_time("Round %s Accuracy (federated): %.4f", current_round, evaluate_metrics_fed["accuracy"])
             # Fine round: calcolo e log del tempo
             round_elapsed = timeit.default_timer() - round_start
 
-            summary = log_file.finalize_round_timing(current_round, round_elapsed)
+            summary = log_file.finalize_round_timing(
+                current_round,
+                round_elapsed,
+                accuracy_centralized=accuracy_centralized,
+                accuracy_federated=accuracy_federated,
+            )
             log_time(
                 "Tempo round %s: totale=%.2f s | crypto=%.2f s | senza_critto=%.2f s",
                 current_round,


### PR DESCRIPTION
### Motivation
- Provide a final PDF report when the target accuracy is reached that includes per-round timings, crypto serialization/deserialization impact, and accuracy values to help quantify the cost of encryption.

### Description
- Extended `log_file.finalize_round_timing` to accept `accuracy_centralized` and `accuracy_federated` and store these values in `ROUND_SUMMARIES`.
- Enhanced `generate_report_pdf` in `framework/py/flwr/common/crypto/log_file.py` to include encryption info, totals (total time, crypto time, non-crypto time), percent crypto impact, and a per-round breakdown including any available centralized/federated accuracies.
- Updated the server loop in `framework/py/flwr/server/server.py` to capture centralized and federated accuracy values (when present) and pass them to `finalize_round_timing` so they are included in the final report.
- Kept the simple PDF writer `_write_simple_pdf` format and appended readable lines describing each round and aggregated statistics.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696ff56dd6a08332972384eca8db0de4)