### PR TITLE
Generate readable text crypto reports when accuracy threshold is met

### DIFF
--- a/framework/py/flwr/common/crypto/log_file.py
+++ b/framework/py/flwr/common/crypto/log_file.py
@@ -1,6 +1,6 @@
 import os
 from datetime import datetime
-from typing import Dict, List
+from typing import Dict, List, Optional
 
 from .config_cripto import ENCRYPTION_METHOD, ENCRYPTION_ENABLED
 
@@ -67,7 +67,13 @@ def add_crypto_time(duration: float) -> None:
     global ROUND_CRYPTO_TIME
     ROUND_CRYPTO_TIME += duration
 
-def finalize_round_timing(round_number: int, round_elapsed: float) -> Dict[str, float]:
+def finalize_round_timing(
+    round_number: int,
+    round_elapsed: float,
+    *,
+    accuracy_centralized: Optional[float] = None,
+    accuracy_federated: Optional[float] = None,
+) -> Dict[str, float]:
     without_crypto = max(round_elapsed - ROUND_CRYPTO_TIME, 0.0)
     summary = {
         "round": float(round_number),
@@ -75,6 +81,10 @@ def finalize_round_timing(round_number: int, round_elapsed: float) -> Dict[str, 
         "crypto_time": ROUND_CRYPTO_TIME,
         "without_crypto": without_crypto,
     }
+    if accuracy_centralized is not None:
+        summary["accuracy_centralized"] = accuracy_centralized
+    if accuracy_federated is not None:
+        summary["accuracy_federated"] = accuracy_federated
     ROUND_SUMMARIES.append(summary)
     return summary
 
@@ -143,13 +153,101 @@ def generate_report_pdf(path: str = "crypto_report.pdf") -> str:
     if not ROUND_SUMMARIES:
         lines = ["Nessun dato di round disponibile."]
     else:
-        first = ROUND_SUMMARIES[0]
         total_time = sum(item["round_time"] for item in ROUND_SUMMARIES)
+        total_crypto = sum(item["crypto_time"] for item in ROUND_SUMMARIES)
+        total_without = sum(item["without_crypto"] for item in ROUND_SUMMARIES)
+        total_impact = (total_crypto / total_time * 100.0) if total_time > 0 else 0.0
+        encryption_info = (
+            f"Crittografia: {ENCRYPTION_METHOD}"
+            if ENCRYPTION_ENABLED
+            else "Crittografia: disabilitata"
+        )
         lines = [
-            f"Primo round: tempo={first['round_time']:.2f}s, senza critto={first['without_crypto']:.2f}s",
-            f"Tempo totale: {total_time:.2f}s",
+            "Report risultati crittografia",
+            encryption_info,
+            f"Round totali: {len(ROUND_SUMMARIES)}",
+            (
+                "Tempo totale: "
+                f"{total_time:.2f}s | critto={total_crypto:.2f}s "
+                f"| senza_critto={total_without:.2f}s | impatto={total_impact:.1f}%"
+            ),
             f"Generato: {datetime.now().isoformat(timespec='seconds')}",
+            "Dettaglio round:",
         ]
+        for item in ROUND_SUMMARIES:
+            impact = (
+                item["crypto_time"] / item["round_time"] * 100.0
+                if item["round_time"] > 0
+                else 0.0
+            )
+            line = (
+                f"- Round {int(item['round'])}: totale={item['round_time']:.2f}s "
+                f"| critto={item['crypto_time']:.2f}s "
+                f"| senza_critto={item['without_crypto']:.2f}s "
+                f"| impatto={impact:.1f}%"
+            )
+            accuracy_parts = []
+            if "accuracy_centralized" in item:
+                accuracy_parts.append(f"acc_cen={item['accuracy_centralized']:.4f}")
+            if "accuracy_federated" in item:
+                accuracy_parts.append(f"acc_fed={item['accuracy_federated']:.4f}")
+            if accuracy_parts:
+                line = f"{line} | " + " ".join(accuracy_parts)
+            lines.append(line)
     _write_simple_pdf(path, lines)
+    REPORT_GENERATED = True
+    return path
+
+def generate_report_txt(path: str = "crypto_report.txt") -> str:
+    """Generate a human-readable text report for crypto/timing results."""
+    global REPORT_GENERATED
+    if REPORT_GENERATED:
+        return path
+    if not ROUND_SUMMARIES:
+        lines = ["Nessun dato di round disponibile."]
+    else:
+        total_time = sum(item["round_time"] for item in ROUND_SUMMARIES)
+        total_crypto = sum(item["crypto_time"] for item in ROUND_SUMMARIES)
+        total_without = sum(item["without_crypto"] for item in ROUND_SUMMARIES)
+        total_impact = (total_crypto / total_time * 100.0) if total_time > 0 else 0.0
+        encryption_info = (
+            f"Crittografia: {ENCRYPTION_METHOD}"
+            if ENCRYPTION_ENABLED
+            else "Crittografia: disabilitata"
+        )
+        lines = [
+            "Report risultati crittografia",
+            encryption_info,
+            f"Round totali: {len(ROUND_SUMMARIES)}",
+            (
+                "Tempo totale: "
+                f"{total_time:.2f}s | critto={total_crypto:.2f}s "
+                f"| senza_critto={total_without:.2f}s | impatto={total_impact:.1f}%"
+            ),
+            f"Generato: {datetime.now().isoformat(timespec='seconds')}",
+            "Dettaglio round:",
+        ]
+        for item in ROUND_SUMMARIES:
+            impact = (
+                item["crypto_time"] / item["round_time"] * 100.0
+                if item["round_time"] > 0
+                else 0.0
+            )
+            line = (
+                f"- Round {int(item['round'])}: totale={item['round_time']:.2f}s "
+                f"| critto={item['crypto_time']:.2f}s "
+                f"| senza_critto={item['without_crypto']:.2f}s "
+                f"| impatto={impact:.1f}%"
+            )
+            accuracy_parts = []
+            if "accuracy_centralized" in item:
+                accuracy_parts.append(f"acc_cen={item['accuracy_centralized']:.4f}")
+            if "accuracy_federated" in item:
+                accuracy_parts.append(f"acc_fed={item['accuracy_federated']:.4f}")
+            if accuracy_parts:
+                line = f"{line} | " + " ".join(accuracy_parts)
+            lines.append(line)
+    with open(path, "w", encoding="utf-8") as txt_file:
+        txt_file.write("\n".join(lines))
     REPORT_GENERATED = True
     return path

--- a/framework/py/flwr/server/server.py
+++ b/framework/py/flwr/server/server.py
@@ -138,6 +138,7 @@ class Server:
 
             # Evaluate model using strategy implementation
             res_cen = self.strategy.evaluate(current_round, parameters=self.parameters)
+            accuracy_centralized: Optional[float] = None
             if res_cen is not None:
                 loss_cen, metrics_cen = res_cen
                 log(INFO, "fit progress: (%s, %s, %s, %s)",
@@ -149,21 +150,29 @@ class Server:
                 )
                 print("metrics_cen",metrics_cen )
                 if "accuracy" in metrics_cen:
+                    accuracy_centralized = float(metrics_cen["accuracy"])
                     log_time("Round %s Accuracy (centralized): %.4f", current_round, metrics_cen["accuracy"])
 
             # Evaluate model on a sample of available clients
             res_fed = self.evaluate_round(server_round=current_round, timeout=timeout)
+            accuracy_federated: Optional[float] = None
             if res_fed is not None:
                 loss_fed, evaluate_metrics_fed, _ = res_fed
                 if loss_fed is not None:
                     history.add_loss_distributed(server_round=current_round, loss=loss_fed)
                     history.add_metrics_distributed(server_round=current_round, metrics=evaluate_metrics_fed)
                     if "accuracy" in evaluate_metrics_fed:
+                       accuracy_federated = float(evaluate_metrics_fed["accuracy"])
                        log_time("Round %s Accuracy (federated): %.4f", current_round, evaluate_metrics_fed["accuracy"])
             # Fine round: calcolo e log del tempo
             round_elapsed = timeit.default_timer() - round_start
 
-            summary = log_file.finalize_round_timing(current_round, round_elapsed)
+            summary = log_file.finalize_round_timing(
+                current_round,
+                round_elapsed,
+                accuracy_centralized=accuracy_centralized,
+                accuracy_federated=accuracy_federated,
+            )
             log_time(
                 "Tempo round %s: totale=%.2f s | crypto=%.2f s | senza_critto=%.2f s",
                 current_round,
@@ -172,7 +181,7 @@ class Server:
                 summary["without_crypto"],
             )
             if log_file.is_report_requested() and not log_file.is_report_generated():
-                report_path = log_file.generate_report_pdf()
+                report_path = log_file.generate_report_txt()
                 log_time("Report crittografia generato: %s", report_path)
 
             history.add_metrics_centralized(


### PR DESCRIPTION
### Motivation
- Provide a readable, easy-to-inspect report of per-round timing and cryptography overhead when accuracy thresholds are reached. 
- Capture centralized and federated accuracy values alongside timing to correlate accuracy vs. crypto cost. 
- Avoid Python 3.10-only typing constructs and produce a plain text report to reduce runtime/compatibility issues with PDF generation.

### Description
- Update `finalize_round_timing` to accept `accuracy_centralized` and `accuracy_federated` as `Optional[float]` and store them in `ROUND_SUMMARIES` when present. 
- Add `generate_report_txt` that emits a human-readable `crypto_report.txt` with totals (total time, crypto time, non-crypto time, percent crypto impact), encryption info, and a per-round breakdown including available accuracy values. 
- Enhance `generate_report_pdf` to include aggregate statistics and per-round accuracy fields if available (kept for backwards compatibility). 
- Modify server loop in `framework/py/flwr/server/server.py` to capture `accuracy_centralized` and `accuracy_federated` (when reported by evaluations), pass them to `finalize_round_timing`, and switch report emission to `generate_report_txt` when a report is requested.

### Testing
- No automated tests were executed for these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696ff56dd6a08332972384eca8db0de4)