### PR TITLE
Stabilize crypto report generation and add text report

### DIFF
--- a/framework/py/flwr/common/crypto/log_file.py
+++ b/framework/py/flwr/common/crypto/log_file.py
@@ -1,6 +1,7 @@
 import os
+import re
 from datetime import datetime
-from typing import Dict, List
+from typing import Dict, List, Optional
 
 from .config_cripto import ENCRYPTION_METHOD, ENCRYPTION_ENABLED
 
@@ -67,7 +68,13 @@ def add_crypto_time(duration: float) -> None:
     global ROUND_CRYPTO_TIME
     ROUND_CRYPTO_TIME += duration
 
-def finalize_round_timing(round_number: int, round_elapsed: float) -> Dict[str, float]:
+def finalize_round_timing(
+    round_number: int,
+    round_elapsed: float,
+    *,
+    accuracy_centralized: Optional[float] = None,
+    accuracy_federated: Optional[float] = None,
+) -> Dict[str, float]:
     without_crypto = max(round_elapsed - ROUND_CRYPTO_TIME, 0.0)
     summary = {
         "round": float(round_number),
@@ -75,6 +82,10 @@ def finalize_round_timing(round_number: int, round_elapsed: float) -> Dict[str, 
         "crypto_time": ROUND_CRYPTO_TIME,
         "without_crypto": without_crypto,
     }
+    if accuracy_centralized is not None:
+        summary["accuracy_centralized"] = accuracy_centralized
+    if accuracy_federated is not None:
+        summary["accuracy_federated"] = accuracy_federated
     ROUND_SUMMARIES.append(summary)
     return summary
 
@@ -90,6 +101,79 @@ def is_report_generated() -> bool:
 
 def _escape_pdf_text(text: str) -> str:
     return text.replace("\\", "\\\\").replace("(", "\\(").replace(")", "\\)")
+
+def _extract_accuracy_from_csv() -> Dict[int, Dict[str, float]]:
+    accuracies: Dict[int, Dict[str, float]] = {}
+    if not CSV_PATH or not os.path.exists(CSV_PATH):
+        return accuracies
+    pattern = re.compile(
+        r"Round\s+(?P<round>\d+)\s+Accuracy\s+\((?P<kind>centralized|federated)\):\s+"
+        r"(?P<value>[-+]?[\d.]+(?:e[-+]?\d+)?)",
+        re.IGNORECASE,
+    )
+    with open(CSV_PATH, "r", encoding="utf-8") as csv_file:
+        for line in csv_file:
+            match = pattern.search(line)
+            if not match:
+                continue
+            round_id = int(match.group("round"))
+            kind = match.group("kind").lower()
+            value = float(match.group("value"))
+            entry = accuracies.setdefault(round_id, {})
+            entry[kind] = value
+    return accuracies
+
+def _build_report_lines() -> List[str]:
+    if not ROUND_SUMMARIES:
+        return ["Nessun dato di round disponibile."]
+    total_time = sum(item["round_time"] for item in ROUND_SUMMARIES)
+    total_crypto = sum(item["crypto_time"] for item in ROUND_SUMMARIES)
+    total_without = sum(item["without_crypto"] for item in ROUND_SUMMARIES)
+    total_impact = (total_crypto / total_time * 100.0) if total_time > 0 else 0.0
+    encryption_info = (
+        f"Crittografia: {ENCRYPTION_METHOD}"
+        if ENCRYPTION_ENABLED
+        else "Crittografia: disabilitata"
+    )
+    accuracy_map = _extract_accuracy_from_csv()
+    lines = [
+        "Report risultati crittografia",
+        encryption_info,
+        f"Round totali: {len(ROUND_SUMMARIES)}",
+        (
+            "Tempo totale: "
+            f"{total_time:.2f}s | critto={total_crypto:.2f}s "
+            f"| senza_critto={total_without:.2f}s | impatto={total_impact:.1f}%"
+        ),
+        f"Generato: {datetime.now().isoformat(timespec='seconds')}",
+        "Dettaglio round:",
+    ]
+    for item in ROUND_SUMMARIES:
+        impact = (
+            item["crypto_time"] / item["round_time"] * 100.0
+            if item["round_time"] > 0
+            else 0.0
+        )
+        line = (
+            f"- Round {int(item['round'])}: totale={item['round_time']:.2f}s "
+            f"| critto={item['crypto_time']:.2f}s "
+            f"| senza_critto={item['without_crypto']:.2f}s "
+            f"| impatto={impact:.1f}%"
+        )
+        accuracy_parts = []
+        if "accuracy_centralized" in item:
+            accuracy_parts.append(f"acc_cen={item['accuracy_centralized']:.4f}")
+        if "accuracy_federated" in item:
+            accuracy_parts.append(f"acc_fed={item['accuracy_federated']:.4f}")
+        csv_accuracy = accuracy_map.get(int(item["round"]), {})
+        if "centralized" in csv_accuracy and "accuracy_centralized" not in item:
+            accuracy_parts.append(f"acc_cen={csv_accuracy['centralized']:.4f}")
+        if "federated" in csv_accuracy and "accuracy_federated" not in item:
+            accuracy_parts.append(f"acc_fed={csv_accuracy['federated']:.4f}")
+        if accuracy_parts:
+            line = f"{line} | " + " ".join(accuracy_parts)
+        lines.append(line)
+    return lines
 
 def _write_simple_pdf(path: str, lines: List[str]) -> None:
     content_lines = []
@@ -140,16 +224,19 @@ def generate_report_pdf(path: str = "crypto_report.pdf") -> str:
     global REPORT_GENERATED
     if REPORT_GENERATED:
         return path
-    if not ROUND_SUMMARIES:
-        lines = ["Nessun dato di round disponibile."]
-    else:
-        first = ROUND_SUMMARIES[0]
-        total_time = sum(item["round_time"] for item in ROUND_SUMMARIES)
-        lines = [
-            f"Primo round: tempo={first['round_time']:.2f}s, senza critto={first['without_crypto']:.2f}s",
-            f"Tempo totale: {total_time:.2f}s",
-            f"Generato: {datetime.now().isoformat(timespec='seconds')}",
-        ]
+    lines = _build_report_lines()
+    generate_report_txt("crypto_report.txt")
     _write_simple_pdf(path, lines)
+    REPORT_GENERATED = True
+    return path
+
+def generate_report_txt(path: str = "crypto_report.txt") -> str:
+    """Generate a human-readable text report for crypto/timing results."""
+    global REPORT_GENERATED
+    if REPORT_GENERATED:
+        return path
+    lines = _build_report_lines()
+    with open(path, "w", encoding="utf-8") as txt_file:
+        txt_file.write("\n".join(lines))
     REPORT_GENERATED = True
     return path


### PR DESCRIPTION
### Motivation
- Avoid introducing regressions in the server loop while improving crypto/timing reporting. 
- Provide a human-readable text report alongside the existing PDF to simplify inspection and reduce PDF-only dependence. 
- Surface per-round accuracy values in reports by extracting them from logs when available. 

### Description
- Updated `finalize_round_timing` in `framework/py/flwr/common/crypto/log_file.py` to accept optional `accuracy_centralized` and `accuracy_federated` parameters and store them in `ROUND_SUMMARIES`. 
- Implemented `_extract_accuracy_from_csv` and `_build_report_lines` in `log_file.py` to parse accuracy lines from the CSV log and build unified report lines. 
- Added `generate_report_txt` to emit a readable `crypto_report.txt` and changed `generate_report_pdf` to reuse the same report lines and also trigger text report generation. 
- Restored/kept the original server loop (no functional changes to `framework/py/flwr/server/server.py`) to prevent client/training failures. 

### Testing
- No automated tests were executed for these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696ff56dd6a08332972384eca8db0de4)