### PR TITLE
Add text crypto timing report generation

### DIFF
--- a/framework/py/flwr/common/crypto/log_file.py
+++ b/framework/py/flwr/common/crypto/log_file.py
@@ -10,6 +10,7 @@ ROUND_CRYPTO_TIME = 0.0
 ROUND_SUMMARIES: List[Dict[str, float]] = []
 REPORT_REQUESTED = False
 REPORT_GENERATED = False
+REPORT_TXT_GENERATED = False
 
 def init_csv():
     global CSV_PATH, CSV_INITIALIZED
@@ -88,6 +89,9 @@ def is_report_requested() -> bool:
 def is_report_generated() -> bool:
     return REPORT_GENERATED
 
+def is_report_txt_generated() -> bool:
+    return REPORT_TXT_GENERATED
+
 def _escape_pdf_text(text: str) -> str:
     return text.replace("\\", "\\\\").replace("(", "\\(").replace(")", "\\)")
 
@@ -152,4 +156,59 @@ def generate_report_pdf(path: str = "crypto_report.pdf") -> str:
         ]
     _write_simple_pdf(path, lines)
     REPORT_GENERATED = True
+    return path
+
+def _build_txt_report_lines() -> List[str]:
+    encryption_label = (
+        f"attiva ({ENCRYPTION_METHOD})" if ENCRYPTION_ENABLED else "disattivata"
+    )
+    lines = [
+        "Report crittografia - riepilogo round",
+        f"Crittografia: {encryption_label}",
+        f"Generato: {datetime.now().isoformat(timespec='seconds')}",
+        "",
+    ]
+    if not ROUND_SUMMARIES:
+        lines.append("Nessun dato di round disponibile.")
+        return lines
+
+    total_time = sum(item["round_time"] for item in ROUND_SUMMARIES)
+    total_crypto = sum(item["crypto_time"] for item in ROUND_SUMMARIES)
+    total_without = sum(item["without_crypto"] for item in ROUND_SUMMARIES)
+    impact_pct = (total_crypto / total_time * 100.0) if total_time > 0 else 0.0
+    lines.extend(
+        [
+            f"Tempo totale: {total_time:.2f}s",
+            f"Tempo crittografia: {total_crypto:.2f}s",
+            f"Tempo senza critto: {total_without:.2f}s",
+            f"Impatto crittografia: {impact_pct:.2f}%",
+            "",
+            "Dettaglio per round:",
+        ]
+    )
+    for item in ROUND_SUMMARIES:
+        round_time = item["round_time"]
+        crypto_time = item["crypto_time"]
+        without_crypto = item["without_crypto"]
+        round_impact = (crypto_time / round_time * 100.0) if round_time > 0 else 0.0
+        lines.append(
+            "Round {round_num}: totale={total:.2f}s | crypto={crypto:.2f}s "
+            "| senza_critto={without:.2f}s | impatto={impact:.2f}%".format(
+                round_num=int(item["round"]),
+                total=round_time,
+                crypto=crypto_time,
+                without=without_crypto,
+                impact=round_impact,
+            )
+        )
+    return lines
+
+def generate_report_txt(path: str = "crypto_report.txt") -> str:
+    global REPORT_TXT_GENERATED
+    if REPORT_TXT_GENERATED:
+        return path
+    lines = _build_txt_report_lines()
+    with open(path, "w", encoding="utf-8") as txt_file:
+        txt_file.write("\n".join(lines) + "\n")
+    REPORT_TXT_GENERATED = True
     return path

--- a/framework/py/flwr/server/server.py
+++ b/framework/py/flwr/server/server.py
@@ -171,9 +171,13 @@ class Server:
                 summary["crypto_time"],
                 summary["without_crypto"],
             )
-            if log_file.is_report_requested() and not log_file.is_report_generated():
-                report_path = log_file.generate_report_pdf()
-                log_time("Report crittografia generato: %s", report_path)
+            if log_file.is_report_requested():
+                if not log_file.is_report_generated():
+                    report_path = log_file.generate_report_pdf()
+                    log_time("Report crittografia generato: %s", report_path)
+                if not log_file.is_report_txt_generated():
+                    report_txt_path = log_file.generate_report_txt()
+                    log_time("Report crittografia testo generato: %s", report_txt_path)
 
             history.add_metrics_centralized(
                 server_round=current_round,


### PR DESCRIPTION
### Motivation
- Provide a plain-text report with crypto timing and impact when training stops at the configured accuracy threshold so timing data (per-round and totals) and encryption mode are persisted in a safe format.

### Description
- Added a text report generator in `framework/py/flwr/common/crypto/log_file.py` with `REPORT_TXT_GENERATED`, `is_report_txt_generated()`, `_build_txt_report_lines()` and `generate_report_txt()` to produce `crypto_report.txt` containing totals, per-round timings, and crypto impact percentage.
- The generated TXT includes the encryption mode (`ENCRYPTION_METHOD` / enabled flag), total/crypto/without-crypto times, per-round breakdown, and computed impact percentages.
- Updated `framework/py/flwr/server/server.py` to trigger `generate_report_txt()` alongside the existing PDF generation when `log_file.request_report_generation()` is set (e.g. when accuracy threshold is reached).
- All new functions and flags are guarded so reports are produced only once per run and existing PDF behavior is preserved.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696fff9b401c833286bbd05120d8cf41)