### PR TITLE
Add per-round crypto timing report and server-side logging on report request

### DIFF
--- a/framework/py/flwr/common/crypto/log_file.py
+++ b/framework/py/flwr/common/crypto/log_file.py
@@ -153,3 +153,42 @@ def generate_report_pdf(path: str = "crypto_report.pdf") -> str:
     _write_simple_pdf(path, lines)
     REPORT_GENERATED = True
     return path
+
+def get_round_summaries() -> List[Dict[str, float]]:
+    return list(ROUND_SUMMARIES)
+
+def build_round_time_report() -> List[str]:
+    if not ROUND_SUMMARIES:
+        return ["Nessun dato di round disponibile."]
+
+    lines = []
+    total_round_time = 0.0
+    total_crypto_time = 0.0
+    for summary in ROUND_SUMMARIES:
+        round_time = summary["round_time"]
+        crypto_time = summary["crypto_time"]
+        without_crypto = summary["without_crypto"]
+        impact = (crypto_time / round_time * 100.0) if round_time > 0 else 0.0
+        lines.append(
+            "Round {round_num}: totale={round_time:.2f}s | "
+            "crypto={crypto_time:.2f}s ({impact:.2f}%) | "
+            "senza_critto={without_crypto:.2f}s".format(
+                round_num=int(summary["round"]),
+                round_time=round_time,
+                crypto_time=crypto_time,
+                impact=impact,
+                without_crypto=without_crypto,
+            )
+        )
+        total_round_time += round_time
+        total_crypto_time += crypto_time
+
+    total_impact = (total_crypto_time / total_round_time * 100.0) if total_round_time > 0 else 0.0
+    lines.append(
+        "Totale critto: {total_crypto:.2f}s su {total_round:.2f}s ({impact:.2f}%)".format(
+            total_crypto=total_crypto_time,
+            total_round=total_round_time,
+            impact=total_impact,
+        )
+    )
+    return lines

--- a/framework/py/flwr/server/server.py
+++ b/framework/py/flwr/server/server.py
@@ -181,6 +181,11 @@ class Server:
             )
 
         # Bookkeeping
+        if log_file.is_report_requested():
+            log_time("=== Report tempi round ===")
+            for line in log_file.build_round_time_report():
+                log_time(line)
+
         end_time = timeit.default_timer()
 
         elapsed= end_time - start_time


### PR DESCRIPTION
### Motivation
- Provide a human-readable breakdown of per-round elapsed time and the time spent in cryptographic operations, including per-round and total crypto impact, so the runtime impact of encryption can be assessed when the target accuracy is reached.
- Emit the assembled timing report into server logs when a crypto report is requested, enabling easy inspection without opening the generated PDF.

### Description
- Add `get_round_summaries()` and `build_round_time_report()` to `framework/py/flwr/common/crypto/log_file.py` to produce per-round report lines and an aggregate crypto-time summary with percent impact. 
- Compute per-round `impact = crypto_time / round_time * 100` and append a final line `Totale critto: ...` with total seconds and overall percentage in `build_round_time_report()`.
- Make the server print the report lines to the log when `log_file.is_report_requested()` is true by calling `log_file.build_round_time_report()` from `framework/py/flwr/server/server.py`.

### Testing
- No automated tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69707eda0b348332b507bf14f1f1f64b)