### PR TITLE
Add cumulative crypto/serialization timing to server summary

### DIFF
--- a/framework/py/flwr/common/crypto/log_file.py
+++ b/framework/py/flwr/common/crypto/log_file.py
@@ -3,6 +3,27 @@ from .config_cripto import ENCRYPTION_METHOD, ENCRYPTION_ENABLED
 
 CSV_PATH = None
 CSV_INITIALIZED = False
+TOTAL_CRYPTO_TIME = 0.0
+TOTAL_SERIAL_TIME = 0.0
+
+
+def reset_crypto_totals() -> None:
+    """Reset accumulated crypto/serialization totals."""
+    global TOTAL_CRYPTO_TIME, TOTAL_SERIAL_TIME
+    TOTAL_CRYPTO_TIME = 0.0
+    TOTAL_SERIAL_TIME = 0.0
+
+
+def add_crypto_time(crypto_time: float, serial_time: float) -> None:
+    """Accumulate crypto and serialization time for summary reporting."""
+    global TOTAL_CRYPTO_TIME, TOTAL_SERIAL_TIME
+    TOTAL_CRYPTO_TIME += crypto_time
+    TOTAL_SERIAL_TIME += serial_time
+
+
+def get_crypto_totals() -> tuple[float, float]:
+    """Return accumulated crypto and serialization totals."""
+    return TOTAL_CRYPTO_TIME, TOTAL_SERIAL_TIME
 
 def init_csv():
     global CSV_PATH, CSV_INITIALIZED

--- a/framework/py/flwr/common/recorddict_compat.py
+++ b/framework/py/flwr/common/recorddict_compat.py
@@ -25,6 +25,7 @@ import psutil
 from . import Array, ArrayRecord, ConfigRecord, MetricRecord, RecordDict
 from .crypto.crypto_selector import encrypt, decrypt, add_integrity, check_integrity
 from .crypto.config_cripto import ENCRYPTION_METHOD,ENCRYPTION_ENABLED, INTEGRITY_ENABLED, INTEGRITY_METHOD
+from .crypto import log_file
 from .crypto.log_file import log_time
 from .typing import (
     Code,
@@ -97,6 +98,7 @@ def arrayrecord_to_parameters(record: ArrayRecord, keep_input: bool) -> Paramete
     # LOG TEMPI REALI
     total_time = total_deser_time + total_decrypt_time
     crypto_impact = (total_decrypt_time / total_time * 100.0) if total_time > 0 else 0.0
+    log_file.add_crypto_time(total_decrypt_time, total_deser_time)
     log_time(
         "CRYPTO STATUS: enabled=%s method=%s | DESERIALIZE: %.5f s | CRYPTO: %.5f s | TOTAL: %.5f s | IMPACT: %.2f%%",
         ENCRYPTION_ENABLED,
@@ -158,6 +160,7 @@ def parameters_to_arrayrecord(parameters: Parameters, keep_input: bool) -> Array
     # LOG
     total_time = tot_serial_time + tot_crypto_time
     crypto_impact = (tot_crypto_time / total_time * 100.0) if total_time > 0 else 0.0
+    log_file.add_crypto_time(tot_crypto_time, tot_serial_time)
     log_time(
         "CRYPTO STATUS: enabled=%s method=%s | SERIALIZE: %.5f s | CRYPTO: %.5f s | TOTAL: %.5f s | IMPACT: %.2f%%",
         ENCRYPTION_ENABLED,

--- a/framework/py/flwr/server/server.py
+++ b/framework/py/flwr/server/server.py
@@ -91,6 +91,7 @@ class Server:
         """Run federated averaging for a number of rounds."""
         log(INFO, "inizio1")
         start_time = timeit.default_timer()
+        log_file.reset_crypto_totals()
         history = History()
         if hasattr(self.strategy, "history"):
                 self.strategy.history = history
@@ -528,6 +529,17 @@ def run_fl(
     log(INFO, "[SUMMARY]")
     log(INFO, "Run finished %s round(s) in %.2fs", config.num_rounds, elapsed_time)
     log_time("Run finished %s round(s) in %.2fs", config.num_rounds, elapsed_time)
+    total_crypto_time, total_serial_time = log_file.get_crypto_totals()
+    crypto_impact = (
+        (total_crypto_time / elapsed_time * 100.0) if elapsed_time > 0 else 0.0
+    )
+    log_time(
+        "Totale critto: %.2f s su %.2f s (%.2f%%) | serializzazione: %.2f s",
+        total_crypto_time,
+        elapsed_time,
+        crypto_impact,
+        total_serial_time,
+    )
 
     # 📩 Messaggio Telegram
     #send_telegram_file(null,"Ho finito!!!!")


### PR DESCRIPTION
### Motivation
- Provide visibility into the total time spent in encryption/decryption and (de)serialization across a full run so the crypto overhead can be quantified and reported in the server summary.

### Description
- Added module-level accumulators and helpers `TOTAL_CRYPTO_TIME`, `TOTAL_SERIAL_TIME`, `reset_crypto_totals()`, `add_crypto_time()` and `get_crypto_totals()` to `framework/py/flwr/common/crypto/log_file.py` to track totals.
- Instrumented `arrayrecord_to_parameters` and `parameters_to_arrayrecord` in `framework/py/flwr/common/recorddict_compat.py` to call `log_file.add_crypto_time(...)` with per-call crypto and serialization durations.
- Reset accumulators at the start of a run by calling `log_file.reset_crypto_totals()` in `Server.fit` and report totals (and percentage impact vs. run elapsed time) in the run summary inside `run_fl` by calling `log_file.get_crypto_totals()`.

### Testing
- No automated tests were run for these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6970b669650c833289cef24f1037adfb)