### PR TITLE
Fix per-round crypto timing and CSV lookup

### DIFF
--- a/framework/py/flwr/server/server.py
+++ b/framework/py/flwr/server/server.py
@@ -115,6 +115,7 @@ class Server:
             log(INFO, "Evaluation returned no results (`None`)")
 
         # Run federated learning for num_rounds
+        prev_crypto_total, _ = log_file.get_crypto_totals()
 
         for current_round in range(1, num_rounds + 1):
             if getattr(self.strategy, "stop_triggered", False):
@@ -162,11 +163,15 @@ class Server:
                        log_time("Round %s Accuracy (federated): %.4f", current_round, evaluate_metrics_fed["accuracy"])
             # Fine round: calcolo e log del tempo
             round_elapsed = timeit.default_timer() - round_start
+            current_crypto_total, _ = log_file.get_crypto_totals()
+            round_crypto_time = max(current_crypto_total - prev_crypto_total, 0.0)
+            prev_crypto_total = current_crypto_total
+            without_crypto = max(round_elapsed - round_crypto_time, 0.0)
             log_file.ROUND_SUMMARIES.append({
                 "round": current_round,
                 "round_time": round_elapsed,
-                "crypto_time": 0.0,          # oppure il tempo reale se lo misuri
-                "without_crypto": round_elapsed,
+                "crypto_time": round_crypto_time,
+                "without_crypto": without_crypto,
             })
 
             log_time("Tempo totale round %s: %.2f s", current_round, round_elapsed)
@@ -563,11 +568,7 @@ def run_fl(
 
     log_time("")  # riga vuota finale
     if log_file.CSV_PATH is not None:
-        # costruisco percorso assoluto (directory + nome file generato)
-        #/home/ns/sarah_falco/flowerCrypto/examples/customCriptography
-        #/home/sarahfalco/IdeaProjects/flowerCrypto/examples/customCriptography
-        base_dir = "/home/ns/sarah_falco/flowerCrypto/examples/customCriptography"
-        abs_path = os.path.join(base_dir, log_file.CSV_PATH)
+        abs_path = os.path.abspath(log_file.CSV_PATH)
 
         if os.path.exists(abs_path):
             send_telegram_file(abs_path, caption="Ecco il log del run")


### PR DESCRIPTION
### Motivation

- The per-round report always showed `crypto_time` as zero because each round summary was hardcoded to `0.0` instead of using measured deltas. 
- The CSV log lookup used a hardcoded base directory which caused `[run_fl] File non trovato` when the process was launched from a different location.

### Description

- Track cumulative crypto totals using `log_file.get_crypto_totals()` and compute per-round crypto time as the delta stored in `round_crypto_time` to populate `ROUND_SUMMARIES`.
- Initialize `prev_crypto_total` before the main round loop and update it each round; compute `without_crypto` and clamp values with `max(..., 0.0)` to avoid negatives.
- Replace the hardcoded CSV base directory with `os.path.abspath(log_file.CSV_PATH)` in `run_fl()` so the generated CSV is located via its actual path.
- Update the round summary entries to store `crypto_time` and `without_crypto` instead of the previous placeholder values.

### Testing

- No automated tests were run for this change (no CI/test invocation was executed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6970bd7b91548332b498c885d8d891b5)