### PR TITLE
Account for parallel crypto execution in round timing and reports

### DIFF
--- a/framework/py/flwr/common/crypto/log_file.py
+++ b/framework/py/flwr/common/crypto/log_file.py
@@ -89,28 +89,41 @@ def build_round_time_report() -> List[str]:
     lines = []
     total_round_time = 0.0
     total_crypto_time = 0.0
+    total_crypto_cumulative = 0.0
 
     for summary in ROUND_SUMMARIES:
         round_time = summary["round_time"]
         crypto_time = summary["crypto_time"]
         without_crypto = summary["without_crypto"]
+        crypto_cumulative = summary.get("crypto_cumulative", crypto_time)
+        parallel_factor = summary.get("parallel_factor")
 
         impact = (crypto_time / round_time * 100.0) if round_time > 0 else 0.0
+
+        parallel_note = (
+            f" | parallel_factor={parallel_factor:.0f}"
+            if parallel_factor is not None
+            else ""
+        )
 
         lines.append(
             "Round {round_num}: totale={round_time:.2f}s | "
             "crypto={crypto_time:.2f}s ({impact:.2f}%) | "
-            "senza_critto={without_crypto:.2f}s".format(
+            "crypto_cum={crypto_cumulative:.2f}s | "
+            "senza_critto={without_crypto:.2f}s{parallel_note}".format(
                 round_num=int(summary["round"]),
                 round_time=round_time,
                 crypto_time=crypto_time,
                 impact=impact,
+                crypto_cumulative=crypto_cumulative,
                 without_crypto=without_crypto,
+                parallel_note=parallel_note,
             )
         )
 
         total_round_time += round_time
         total_crypto_time += crypto_time
+        total_crypto_cumulative += crypto_cumulative
 
     total_impact = (
         (total_crypto_time / total_round_time * 100.0)
@@ -119,11 +132,17 @@ def build_round_time_report() -> List[str]:
     )
 
     lines.append(
-        "Totale critto: {total_crypto:.2f}s su {total_round:.2f}s ({impact:.2f}%)".format(
+        "Totale critto (parallel): {total_crypto:.2f}s su {total_round:.2f}s ({impact:.2f}%)".format(
             total_crypto=total_crypto_time,
             total_round=total_round_time,
             impact=total_impact,
         )
     )
+    if total_crypto_cumulative != total_crypto_time:
+        lines.append(
+            "Totale critto cumulativo: {total_crypto:.2f}s".format(
+                total_crypto=total_crypto_cumulative
+            )
+        )
 
     return lines

--- a/framework/py/flwr/server/server.py
+++ b/framework/py/flwr/server/server.py
@@ -166,11 +166,17 @@ class Server:
             current_crypto_total, _ = log_file.get_crypto_totals()
             round_crypto_time = max(current_crypto_total - prev_crypto_total, 0.0)
             prev_crypto_total = current_crypto_total
-            without_crypto = max(round_elapsed - round_crypto_time, 0.0)
+            parallel_factor = max(self.max_workers, 1)
+            parallel_crypto_time = min(
+                round_crypto_time / parallel_factor, round_elapsed
+            )
+            without_crypto = max(round_elapsed - parallel_crypto_time, 0.0)
             log_file.ROUND_SUMMARIES.append({
                 "round": current_round,
                 "round_time": round_elapsed,
-                "crypto_time": round_crypto_time,
+                "crypto_time": parallel_crypto_time,
+                "crypto_cumulative": round_crypto_time,
+                "parallel_factor": float(parallel_factor),
                 "without_crypto": without_crypto,
             })
 


### PR DESCRIPTION
### Motivation
- Make reported per-round crypto time more realistic by accounting for parallel execution across worker threads. 
- Preserve cumulative crypto timing so total work spent in crypto remains visible even when parallelized. 
- Improve observability by exposing the parallelization factor and cumulative crypto time in the round report.

### Description
- In `Server`, compute `parallel_factor = max(self.max_workers, 1)` and `parallel_crypto_time = min(round_crypto_time / parallel_factor, round_elapsed)` and store `crypto_time` as `parallel_crypto_time` in `ROUND_SUMMARIES` while also adding `crypto_cumulative` and `parallel_factor` fields. 
- In `framework/py/flwr/common/crypto/log_file.py`, read `crypto_cumulative` and `parallel_factor` from summaries and include `crypto_cum` and `parallel_factor` in each round report line. 
- Track `total_crypto_cumulative` alongside the parallel-adjusted total and append a separate "Totale critto cumulativo" line when cumulative differs from the parallel-adjusted total. 
- Update the aggregate total label to indicate it is the parallel-adjusted crypto total (`Totale critto (parallel)`).

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6970dc4cee488332b9e37929705f4a76)