### PR TITLE
Handle unset max_workers and expose parallel crypto metrics in reports

### DIFF
--- a/framework/py/flwr/common/crypto/log_file.py
+++ b/framework/py/flwr/common/crypto/log_file.py
@@ -89,28 +89,41 @@ def build_round_time_report() -> List[str]:
     lines = []
     total_round_time = 0.0
     total_crypto_time = 0.0
+    total_crypto_cumulative = 0.0
 
     for summary in ROUND_SUMMARIES:
         round_time = summary["round_time"]
         crypto_time = summary["crypto_time"]
         without_crypto = summary["without_crypto"]
+        crypto_cumulative = summary.get("crypto_cumulative", crypto_time)
+        parallel_factor = summary.get("parallel_factor")
 
         impact = (crypto_time / round_time * 100.0) if round_time > 0 else 0.0
+
+        parallel_note = (
+            f" | parallel_factor={parallel_factor:.0f}"
+            if parallel_factor is not None
+            else ""
+        )
 
         lines.append(
             "Round {round_num}: totale={round_time:.2f}s | "
             "crypto={crypto_time:.2f}s ({impact:.2f}%) | "
-            "senza_critto={without_crypto:.2f}s".format(
+            "crypto_cum={crypto_cumulative:.2f}s | "
+            "senza_critto={without_crypto:.2f}s{parallel_note}".format(
                 round_num=int(summary["round"]),
                 round_time=round_time,
                 crypto_time=crypto_time,
                 impact=impact,
+                crypto_cumulative=crypto_cumulative,
                 without_crypto=without_crypto,
+                parallel_note=parallel_note,
             )
         )
 
         total_round_time += round_time
         total_crypto_time += crypto_time
+        total_crypto_cumulative += crypto_cumulative
 
     total_impact = (
         (total_crypto_time / total_round_time * 100.0)
@@ -119,11 +132,17 @@ def build_round_time_report() -> List[str]:
     )
 
     lines.append(
-        "Totale critto: {total_crypto:.2f}s su {total_round:.2f}s ({impact:.2f}%)".format(
+        "Totale critto (parallel): {total_crypto:.2f}s su {total_round:.2f}s ({impact:.2f}%)".format(
             total_crypto=total_crypto_time,
             total_round=total_round_time,
             impact=total_impact,
         )
     )
+    if total_crypto_cumulative != total_crypto_time:
+        lines.append(
+            "Totale critto cumulativo: {total_crypto:.2f}s".format(
+                total_crypto=total_crypto_cumulative
+            )
+        )
 
     return lines

--- a/framework/py/flwr/server/server.py
+++ b/framework/py/flwr/server/server.py
@@ -166,11 +166,21 @@ class Server:
             current_crypto_total, _ = log_file.get_crypto_totals()
             round_crypto_time = max(current_crypto_total - prev_crypto_total, 0.0)
             prev_crypto_total = current_crypto_total
-            without_crypto = max(round_elapsed - round_crypto_time, 0.0)
+            parallel_factor = (
+                self.max_workers
+                if self.max_workers is not None and self.max_workers > 0
+                else 1
+            )
+            parallel_crypto_time = min(
+                round_crypto_time / parallel_factor, round_elapsed
+            )
+            without_crypto = max(round_elapsed - parallel_crypto_time, 0.0)
             log_file.ROUND_SUMMARIES.append({
                 "round": current_round,
                 "round_time": round_elapsed,
-                "crypto_time": round_crypto_time,
+                "crypto_time": parallel_crypto_time,
+                "crypto_cumulative": round_crypto_time,
+                "parallel_factor": float(parallel_factor),
                 "without_crypto": without_crypto,
             })
 


### PR DESCRIPTION
### Motivation
- Make per-round crypto timing more realistic by accounting for parallel execution across worker threads and surface both the parallel-adjusted and cumulative crypto times in reports.
- Fix a runtime `TypeError` that occurred when `self.max_workers` was `None` while computing the parallelization factor.

### Description
- Guard against `None` or non-positive `self.max_workers` when computing the parallel factor by using `self.max_workers` if set and positive, otherwise falling back to `1` when computing `parallel_factor`.
- Compute `parallel_crypto_time = min(round_crypto_time / parallel_factor, round_elapsed)` and record `crypto_time` as the parallel-adjusted value in `log_file.ROUND_SUMMARIES` while also storing `crypto_cumulative` and `parallel_factor` in each summary.
- Update `build_round_time_report()` in `framework/py/flwr/common/crypto/log_file.py` to include `crypto_cum` and `parallel_factor` per round, label the aggregate as `Totale critto (parallel)`, and append a `Totale critto cumulativo` line when the cumulative total differs from the parallel-adjusted total.
- Ensure `without_crypto` is computed as the positive remainder after subtracting the parallel-adjusted crypto time from the round elapsed time.

### Testing
- No automated tests were executed for these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6970dc4cee488332b9e37929705f4a76)