### PR TITLE
Compute parallel-aware crypto time from sampled client counts and add parallel metrics to reports

### DIFF
--- a/framework/py/flwr/common/crypto/log_file.py
+++ b/framework/py/flwr/common/crypto/log_file.py
@@ -89,28 +89,41 @@ def build_round_time_report() -> List[str]:
     lines = []
     total_round_time = 0.0
     total_crypto_time = 0.0
+    total_crypto_cumulative = 0.0
 
     for summary in ROUND_SUMMARIES:
         round_time = summary["round_time"]
         crypto_time = summary["crypto_time"]
         without_crypto = summary["without_crypto"]
+        crypto_cumulative = summary.get("crypto_cumulative", crypto_time)
+        parallel_factor = summary.get("parallel_factor")
 
         impact = (crypto_time / round_time * 100.0) if round_time > 0 else 0.0
+
+        parallel_note = (
+            f" | parallel_factor={parallel_factor:.0f}"
+            if parallel_factor is not None
+            else ""
+        )
 
         lines.append(
             "Round {round_num}: totale={round_time:.2f}s | "
             "crypto={crypto_time:.2f}s ({impact:.2f}%) | "
-            "senza_critto={without_crypto:.2f}s".format(
+            "crypto_cum={crypto_cumulative:.2f}s | "
+            "senza_critto={without_crypto:.2f}s{parallel_note}".format(
                 round_num=int(summary["round"]),
                 round_time=round_time,
                 crypto_time=crypto_time,
                 impact=impact,
+                crypto_cumulative=crypto_cumulative,
                 without_crypto=without_crypto,
+                parallel_note=parallel_note,
             )
         )
 
         total_round_time += round_time
         total_crypto_time += crypto_time
+        total_crypto_cumulative += crypto_cumulative
 
     total_impact = (
         (total_crypto_time / total_round_time * 100.0)
@@ -119,11 +132,17 @@ def build_round_time_report() -> List[str]:
     )
 
     lines.append(
-        "Totale critto: {total_crypto:.2f}s su {total_round:.2f}s ({impact:.2f}%)".format(
+        "Totale critto (parallel): {total_crypto:.2f}s su {total_round:.2f}s ({impact:.2f}%)".format(
             total_crypto=total_crypto_time,
             total_round=total_round_time,
             impact=total_impact,
         )
     )
+    if total_crypto_cumulative != total_crypto_time:
+        lines.append(
+            "Totale critto cumulativo: {total_crypto:.2f}s".format(
+                total_crypto=total_crypto_cumulative
+            )
+        )
 
     return lines

--- a/framework/py/flwr/server/server.py
+++ b/framework/py/flwr/server/server.py
@@ -128,6 +128,8 @@ class Server:
             log_time(f"[ROUND {current_round}]")
 
             # Train model
+            round_fit_clients = 0
+            round_eval_clients = 0
             res_fit = self.fit_round(server_round=current_round, timeout=timeout)
             if res_fit is not None:
                 parameters_prime, fit_metrics, _ = res_fit  # fit_metrics_aggregated
@@ -136,6 +138,8 @@ class Server:
                 history.add_metrics_distributed_fit(
                     server_round=current_round, metrics=fit_metrics
                 )
+                fit_results, _ = res_fit[2]
+                round_fit_clients = len(fit_results)
 
             # Evaluate model using strategy implementation
             res_cen = self.strategy.evaluate(current_round, parameters=self.parameters)
@@ -161,16 +165,28 @@ class Server:
                     history.add_metrics_distributed(server_round=current_round, metrics=evaluate_metrics_fed)
                     if "accuracy" in evaluate_metrics_fed:
                        log_time("Round %s Accuracy (federated): %.4f", current_round, evaluate_metrics_fed["accuracy"])
+                eval_results, _ = res_fed[2]
+                round_eval_clients = len(eval_results)
             # Fine round: calcolo e log del tempo
             round_elapsed = timeit.default_timer() - round_start
             current_crypto_total, _ = log_file.get_crypto_totals()
             round_crypto_time = max(current_crypto_total - prev_crypto_total, 0.0)
             prev_crypto_total = current_crypto_total
-            without_crypto = max(round_elapsed - round_crypto_time, 0.0)
+            sampled_clients = max(round_fit_clients, round_eval_clients, 1)
+            if self.max_workers is not None and self.max_workers > 0:
+                parallel_factor = max(1, min(self.max_workers, sampled_clients))
+            else:
+                parallel_factor = sampled_clients
+            parallel_crypto_time = min(
+                round_crypto_time / parallel_factor, round_elapsed
+            )
+            without_crypto = max(round_elapsed - parallel_crypto_time, 0.0)
             log_file.ROUND_SUMMARIES.append({
                 "round": current_round,
                 "round_time": round_elapsed,
-                "crypto_time": round_crypto_time,
+                "crypto_time": parallel_crypto_time,
+                "crypto_cumulative": round_crypto_time,
+                "parallel_factor": float(parallel_factor),
                 "without_crypto": without_crypto,
             })
 


### PR DESCRIPTION
### Motivation
- Make per-round crypto timing realistic by accounting for actual parallelism instead of summing all crypto durations across workers. 
- Avoid misleading percentages >100% by adjusting the reported crypto time for parallel execution and keep cumulative totals for reference. 

### Description
- Estimate the per-round parallel factor from sampled client counts and cap it by `max_workers` when provided, falling back to sampled client counts when `max_workers` is unset. 
- Use the computed `parallel_factor` to derive `parallel_crypto_time = min(round_crypto_time / parallel_factor, round_elapsed)` and store it in `ROUND_SUMMARIES` instead of the raw cumulative value. 
- Append `crypto_cumulative` and `parallel_factor` to each round summary and update `build_round_time_report()` in `framework/py/flwr/common/crypto/log_file.py` to show per-round `crypto_cum` and `parallel_factor`, a `Totale critto (parallel)` line and a `Totale critto cumulativo` line when they differ. 
- Key changes in `framework/py/flwr/server/server.py` adjust how `round_fit_clients` and `round_eval_clients` are computed and derive `sampled_clients` to compute the parallel factor used for crypto accounting. 

### Testing
- No automated tests were executed for these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6970dc4cee488332b9e37929705f4a76)