### PR TITLE
Track per-round concurrency and use it for parallel-aware crypto timing

### DIFF
--- a/framework/py/flwr/common/crypto/log_file.py
+++ b/framework/py/flwr/common/crypto/log_file.py
@@ -89,28 +89,41 @@ def build_round_time_report() -> List[str]:
     lines = []
     total_round_time = 0.0
     total_crypto_time = 0.0
+    total_crypto_cumulative = 0.0
 
     for summary in ROUND_SUMMARIES:
         round_time = summary["round_time"]
         crypto_time = summary["crypto_time"]
         without_crypto = summary["without_crypto"]
+        crypto_cumulative = summary.get("crypto_cumulative", crypto_time)
+        parallel_factor = summary.get("parallel_factor")
 
         impact = (crypto_time / round_time * 100.0) if round_time > 0 else 0.0
+
+        parallel_note = (
+            f" | parallel_factor={parallel_factor:.0f}"
+            if parallel_factor is not None
+            else ""
+        )
 
         lines.append(
             "Round {round_num}: totale={round_time:.2f}s | "
             "crypto={crypto_time:.2f}s ({impact:.2f}%) | "
-            "senza_critto={without_crypto:.2f}s".format(
+            "crypto_cum={crypto_cumulative:.2f}s | "
+            "senza_critto={without_crypto:.2f}s{parallel_note}".format(
                 round_num=int(summary["round"]),
                 round_time=round_time,
                 crypto_time=crypto_time,
                 impact=impact,
+                crypto_cumulative=crypto_cumulative,
                 without_crypto=without_crypto,
+                parallel_note=parallel_note,
             )
         )
 
         total_round_time += round_time
         total_crypto_time += crypto_time
+        total_crypto_cumulative += crypto_cumulative
 
     total_impact = (
         (total_crypto_time / total_round_time * 100.0)
@@ -119,11 +132,17 @@ def build_round_time_report() -> List[str]:
     )
 
     lines.append(
-        "Totale critto: {total_crypto:.2f}s su {total_round:.2f}s ({impact:.2f}%)".format(
+        "Totale critto (parallel): {total_crypto:.2f}s su {total_round:.2f}s ({impact:.2f}%)".format(
             total_crypto=total_crypto_time,
             total_round=total_round_time,
             impact=total_impact,
         )
     )
+    if total_crypto_cumulative != total_crypto_time:
+        lines.append(
+            "Totale critto cumulativo: {total_crypto:.2f}s".format(
+                total_crypto=total_crypto_cumulative
+            )
+        )
 
     return lines

--- a/framework/py/flwr/server/server.py
+++ b/framework/py/flwr/server/server.py
@@ -18,6 +18,7 @@
 import concurrent.futures
 import io
 import os
+import threading
 import timeit
 from logging import INFO, WARN
 from typing import Optional, Union
@@ -52,6 +53,8 @@ EvaluateResultsAndFailures = tuple[
     list[tuple[ClientProxy, EvaluateRes]],
     list[Union[tuple[ClientProxy, EvaluateRes], BaseException]],
 ]
+FitResultsFailuresAndParallel = tuple[FitResultsAndFailures, int]
+EvaluateResultsFailuresAndParallel = tuple[EvaluateResultsAndFailures, int]
 ReconnectResultsAndFailures = tuple[
     list[tuple[ClientProxy, DisconnectRes]],
     list[Union[tuple[ClientProxy, DisconnectRes], BaseException]],
@@ -128,6 +131,10 @@ class Server:
             log_time(f"[ROUND {current_round}]")
 
             # Train model
+            round_fit_clients = 0
+            round_eval_clients = 0
+            fit_parallel_factor = 0
+            eval_parallel_factor = 0
             res_fit = self.fit_round(server_round=current_round, timeout=timeout)
             if res_fit is not None:
                 parameters_prime, fit_metrics, _ = res_fit  # fit_metrics_aggregated
@@ -136,6 +143,8 @@ class Server:
                 history.add_metrics_distributed_fit(
                     server_round=current_round, metrics=fit_metrics
                 )
+                fit_results, _, fit_parallel_factor = res_fit[2]
+                round_fit_clients = len(fit_results)
 
             # Evaluate model using strategy implementation
             res_cen = self.strategy.evaluate(current_round, parameters=self.parameters)
@@ -161,16 +170,24 @@ class Server:
                     history.add_metrics_distributed(server_round=current_round, metrics=evaluate_metrics_fed)
                     if "accuracy" in evaluate_metrics_fed:
                        log_time("Round %s Accuracy (federated): %.4f", current_round, evaluate_metrics_fed["accuracy"])
+                eval_results, _, eval_parallel_factor = res_fed[2]
+                round_eval_clients = len(eval_results)
             # Fine round: calcolo e log del tempo
             round_elapsed = timeit.default_timer() - round_start
             current_crypto_total, _ = log_file.get_crypto_totals()
             round_crypto_time = max(current_crypto_total - prev_crypto_total, 0.0)
             prev_crypto_total = current_crypto_total
-            without_crypto = max(round_elapsed - round_crypto_time, 0.0)
+            parallel_factor = max(fit_parallel_factor, eval_parallel_factor, 1)
+            parallel_crypto_time = min(
+                round_crypto_time / parallel_factor, round_elapsed
+            )
+            without_crypto = max(round_elapsed - parallel_crypto_time, 0.0)
             log_file.ROUND_SUMMARIES.append({
                 "round": current_round,
                 "round_time": round_elapsed,
-                "crypto_time": round_crypto_time,
+                "crypto_time": parallel_crypto_time,
+                "crypto_cumulative": round_crypto_time,
+                "parallel_factor": float(parallel_factor),
                 "without_crypto": without_crypto,
             })
 
@@ -196,7 +213,7 @@ class Server:
         server_round: int,
         timeout: Optional[float],
     ) -> Optional[
-        tuple[Optional[float], dict[str, Scalar], EvaluateResultsAndFailures]
+        tuple[Optional[float], dict[str, Scalar], EvaluateResultsFailuresAndParallel]
     ]:
         """Validate current global model on a number of clients."""
         # Get clients and their respective instructions from strategy
@@ -216,7 +233,7 @@ class Server:
         )
 
         # Collect `evaluate` results from all clients participating in this round
-        results, failures = evaluate_clients(
+        (results, failures), parallel_factor = evaluate_clients(
             client_instructions,
             max_workers=self.max_workers,
             timeout=timeout,
@@ -236,14 +253,18 @@ class Server:
         ] = self.strategy.aggregate_evaluate(server_round, results, failures)
 
         loss_aggregated, metrics_aggregated = aggregated_result
-        return loss_aggregated, metrics_aggregated, (results, failures)
+        return loss_aggregated, metrics_aggregated, (
+            results,
+            failures,
+            parallel_factor,
+        )
 
     def fit_round(
         self,
         server_round: int,
         timeout: Optional[float],
     ) -> Optional[
-        tuple[Optional[Parameters], dict[str, Scalar], FitResultsAndFailures]
+        tuple[Optional[Parameters], dict[str, Scalar], FitResultsFailuresAndParallel]
     ]:
         """Perform a single round of federated averaging."""
         # Get clients and their respective instructions from strategy
@@ -264,7 +285,7 @@ class Server:
         )
 
         # Collect `fit` results from all clients participating in this round
-        results, failures = fit_clients(
+        (results, failures), parallel_factor = fit_clients(
             client_instructions=client_instructions,
             max_workers=self.max_workers,
             timeout=timeout,
@@ -284,7 +305,11 @@ class Server:
         ] = self.strategy.aggregate_fit(server_round, results, failures)
 
         parameters_aggregated, metrics_aggregated = aggregated_result
-        return parameters_aggregated, metrics_aggregated, (results, failures)
+        return parameters_aggregated, metrics_aggregated, (
+            results,
+            failures,
+            parallel_factor,
+        )
 
     def disconnect_all_clients(self, timeout: Optional[float]) -> None:
         """Send shutdown signal to all clients."""
@@ -376,11 +401,28 @@ def fit_clients(
     max_workers: Optional[int],
     timeout: Optional[float],
     group_id: int,
-) -> FitResultsAndFailures:
+) -> tuple[FitResultsAndFailures, int]:
     """Refine parameters concurrently on all selected clients."""
+    max_concurrency = 0
+    active_tasks = 0
+    lock = threading.Lock()
+
+    def tracked_fit(
+        client_proxy: ClientProxy, ins: FitIns, timeout: Optional[float], group_id: int
+    ) -> tuple[ClientProxy, FitRes]:
+        nonlocal max_concurrency, active_tasks
+        with lock:
+            active_tasks += 1
+            max_concurrency = max(max_concurrency, active_tasks)
+        try:
+            return fit_client(client_proxy, ins, timeout, group_id)
+        finally:
+            with lock:
+                active_tasks -= 1
+
     with concurrent.futures.ThreadPoolExecutor(max_workers=max_workers) as executor:
         submitted_fs = {
-            executor.submit(fit_client, client_proxy, ins, timeout, group_id)
+            executor.submit(tracked_fit, client_proxy, ins, timeout, group_id)
             for client_proxy, ins in client_instructions
         }
         finished_fs, _ = concurrent.futures.wait(
@@ -395,7 +437,7 @@ def fit_clients(
         _handle_finished_future_after_fit(
             future=future, results=results, failures=failures
         )
-    return results, failures
+    return (results, failures), max_concurrency
 
 
 def fit_client(
@@ -436,11 +478,31 @@ def evaluate_clients(
     max_workers: Optional[int],
     timeout: Optional[float],
     group_id: int,
-) -> EvaluateResultsAndFailures:
+) -> tuple[EvaluateResultsAndFailures, int]:
     """Evaluate parameters concurrently on all selected clients."""
+    max_concurrency = 0
+    active_tasks = 0
+    lock = threading.Lock()
+
+    def tracked_evaluate(
+        client_proxy: ClientProxy,
+        ins: EvaluateIns,
+        timeout: Optional[float],
+        group_id: int,
+    ) -> tuple[ClientProxy, EvaluateRes]:
+        nonlocal max_concurrency, active_tasks
+        with lock:
+            active_tasks += 1
+            max_concurrency = max(max_concurrency, active_tasks)
+        try:
+            return evaluate_client(client_proxy, ins, timeout, group_id)
+        finally:
+            with lock:
+                active_tasks -= 1
+
     with concurrent.futures.ThreadPoolExecutor(max_workers=max_workers) as executor:
         submitted_fs = {
-            executor.submit(evaluate_client, client_proxy, ins, timeout, group_id)
+            executor.submit(tracked_evaluate, client_proxy, ins, timeout, group_id)
             for client_proxy, ins in client_instructions
         }
         finished_fs, _ = concurrent.futures.wait(
@@ -455,7 +517,7 @@ def evaluate_clients(
         _handle_finished_future_after_evaluate(
             future=future, results=results, failures=failures
         )
-    return results, failures
+    return (results, failures), max_concurrency
 
 
 def evaluate_client(

--- a/framework/py/flwr/server/server_test.py
+++ b/framework/py/flwr/server/server_test.py
@@ -145,7 +145,7 @@ def test_fit_clients() -> None:
     client_instructions = [(c, ins) for c in clients]
 
     # Execute
-    results, failures = fit_clients(client_instructions, None, None, 0)
+    (results, failures), _ = fit_clients(client_instructions, None, None, 0)
 
     # Assert
     assert len(results) == 1
@@ -169,7 +169,7 @@ def test_eval_clients() -> None:
     client_instructions = [(c, ins) for c in clients]
 
     # Execute
-    results, failures = evaluate_clients(
+    (results, failures), _ = evaluate_clients(
         client_instructions=client_instructions,
         max_workers=None,
         timeout=None,


### PR DESCRIPTION
### Motivation
- Make per-round crypto timing more realistic by estimating actual parallelism from observed concurrency instead of inferring it from sampled client counts or max_workers.
- Avoid reporting misleading crypto times (e.g. percentages >100%) by dividing cumulative crypto time by the measured parallel factor and capping it by the round duration.

### Description
- Track active tasks and compute `max_concurrency` inside `fit_clients` and `evaluate_clients` by wrapping tasks with `tracked_fit` / `tracked_evaluate` and protecting counters with a `threading.Lock`.
- Change `fit_clients` and `evaluate_clients` to return `((results, failures), max_concurrency)` and add type aliases `FitResultsFailuresAndParallel` and `EvaluateResultsFailuresAndParallel` to reflect the new return shape.
- Unpack the returned `parallel_factor` in `Server.fit_round` and `Server.evaluate_round`, use `parallel_factor = max(fit_parallel_factor, eval_parallel_factor, 1)`, compute `parallel_crypto_time = min(round_crypto_time / parallel_factor, round_elapsed)`, and store `crypto_time`, `crypto_cumulative`, and `parallel_factor` in `log_file.ROUND_SUMMARIES`.
- Update `framework/py/flwr/common/crypto/log_file.py` to include `crypto_cumulative` and `parallel_factor` in per-round reports, show a `Totale critto (parallel)` line and a `Totale critto cumulativo` line when they differ.
- Update unit tests in `framework/py/flwr/server/server_test.py` to unpack the new tuple return values from `fit_clients`/`evaluate_clients`.

### Testing
- No automated tests or CI jobs were executed for this change (no test run requested). 
- Unit test files were updated (`framework/py/flwr/server/server_test.py`) to reflect the API change in `fit_clients`/`evaluate_clients` but were not executed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6970dc4cee488332b9e37929705f4a76)