### PR TITLE
Add phase-aware crypto timing aggregation

### DIFF
--- a/framework/py/flwr/common/crypto/log_file.py
+++ b/framework/py/flwr/common/crypto/log_file.py
@@ -1,5 +1,5 @@
 import os
-from typing import List, Dict
+from typing import List, Dict, Tuple
 
 from .config_cripto import ENCRYPTION_METHOD, ENCRYPTION_ENABLED
 
@@ -7,25 +7,51 @@ CSV_PATH = None
 CSV_INITIALIZED = False
 TOTAL_CRYPTO_TIME = 0.0
 TOTAL_SERIAL_TIME = 0.0
+TOTAL_CRYPTO_TIME_BY_GROUP: Dict[str, float] = {}
+TOTAL_SERIAL_TIME_BY_GROUP: Dict[str, float] = {}
 
 
 def reset_crypto_totals() -> None:
     """Reset accumulated crypto/serialization totals."""
-    global TOTAL_CRYPTO_TIME, TOTAL_SERIAL_TIME
+    global TOTAL_CRYPTO_TIME, TOTAL_SERIAL_TIME, TOTAL_CRYPTO_TIME_BY_GROUP, TOTAL_SERIAL_TIME_BY_GROUP
     TOTAL_CRYPTO_TIME = 0.0
     TOTAL_SERIAL_TIME = 0.0
+    TOTAL_CRYPTO_TIME_BY_GROUP = {}
+    TOTAL_SERIAL_TIME_BY_GROUP = {}
 
 
-def add_crypto_time(crypto_time: float, serial_time: float) -> None:
+def add_crypto_time(
+    crypto_time: float, serial_time: float, group: str | None = None
+) -> None:
     """Accumulate crypto and serialization time for summary reporting."""
     global TOTAL_CRYPTO_TIME, TOTAL_SERIAL_TIME
     TOTAL_CRYPTO_TIME += crypto_time
     TOTAL_SERIAL_TIME += serial_time
+    group_key = group or "unknown"
+    TOTAL_CRYPTO_TIME_BY_GROUP[group_key] = (
+        TOTAL_CRYPTO_TIME_BY_GROUP.get(group_key, 0.0) + crypto_time
+    )
+    TOTAL_SERIAL_TIME_BY_GROUP[group_key] = (
+        TOTAL_SERIAL_TIME_BY_GROUP.get(group_key, 0.0) + serial_time
+    )
 
 
-def get_crypto_totals() -> tuple[float, float]:
+def get_crypto_totals(group: str | None = None) -> tuple[float, float]:
     """Return accumulated crypto and serialization totals."""
+    if group is not None:
+        return (
+            TOTAL_CRYPTO_TIME_BY_GROUP.get(group, 0.0),
+            TOTAL_SERIAL_TIME_BY_GROUP.get(group, 0.0),
+        )
     return TOTAL_CRYPTO_TIME, TOTAL_SERIAL_TIME
+
+
+def get_crypto_totals_by_group() -> Dict[str, Tuple[float, float]]:
+    """Return accumulated crypto/serialization totals by group."""
+    return {
+        key: (TOTAL_CRYPTO_TIME_BY_GROUP.get(key, 0.0), TOTAL_SERIAL_TIME_BY_GROUP.get(key, 0.0))
+        for key in set(TOTAL_CRYPTO_TIME_BY_GROUP) | set(TOTAL_SERIAL_TIME_BY_GROUP)
+    }
 
 ROUND_SUMMARIES: List[Dict[str, float]] = []
 
@@ -90,12 +116,18 @@ def build_round_time_report() -> List[str]:
     total_round_time = 0.0
     total_crypto_time = 0.0
     total_crypto_cumulative = 0.0
+    total_crypto_fit = 0.0
+    total_crypto_eval = 0.0
+    total_crypto_other = 0.0
 
     for summary in ROUND_SUMMARIES:
         round_time = summary["round_time"]
         crypto_time = summary["crypto_time"]
         without_crypto = summary["without_crypto"]
         crypto_cumulative = summary.get("crypto_cumulative", crypto_time)
+        crypto_fit = summary.get("crypto_fit")
+        crypto_eval = summary.get("crypto_eval")
+        crypto_other = summary.get("crypto_other")
         parallel_factor = summary.get("parallel_factor")
         parallel_fit = summary.get("parallel_fit")
         parallel_eval = summary.get("parallel_eval")
@@ -109,6 +141,12 @@ def build_round_time_report() -> List[str]:
             parallel_note_parts.append(f"parallel_fit={parallel_fit:.0f}")
         if parallel_eval is not None:
             parallel_note_parts.append(f"parallel_eval={parallel_eval:.0f}")
+        if crypto_fit is not None:
+            parallel_note_parts.append(f"crypto_fit={crypto_fit:.2f}s")
+        if crypto_eval is not None:
+            parallel_note_parts.append(f"crypto_eval={crypto_eval:.2f}s")
+        if crypto_other is not None:
+            parallel_note_parts.append(f"crypto_other={crypto_other:.2f}s")
         parallel_note = f" | {' | '.join(parallel_note_parts)}" if parallel_note_parts else ""
 
         lines.append(
@@ -129,6 +167,12 @@ def build_round_time_report() -> List[str]:
         total_round_time += round_time
         total_crypto_time += crypto_time
         total_crypto_cumulative += crypto_cumulative
+        if crypto_fit is not None:
+            total_crypto_fit += crypto_fit
+        if crypto_eval is not None:
+            total_crypto_eval += crypto_eval
+        if crypto_other is not None:
+            total_crypto_other += crypto_other
 
     total_impact = (
         (total_crypto_time / total_round_time * 100.0)
@@ -143,6 +187,14 @@ def build_round_time_report() -> List[str]:
             impact=total_impact,
         )
     )
+    if any(value > 0 for value in (total_crypto_fit, total_crypto_eval, total_crypto_other)):
+        lines.append(
+            "Totale critto per fase: fit={fit:.2f}s | evaluate={evaluate:.2f}s | other={other:.2f}s".format(
+                fit=total_crypto_fit,
+                evaluate=total_crypto_eval,
+                other=total_crypto_other,
+            )
+        )
     if total_crypto_cumulative != total_crypto_time:
         lines.append(
             "Totale critto cumulativo: {total_crypto:.2f}s".format(

--- a/framework/py/flwr/common/recorddict_compat.py
+++ b/framework/py/flwr/common/recorddict_compat.py
@@ -48,7 +48,9 @@ EMPTY_TENSOR_KEY = "_empty"
 import time
 
 
-def arrayrecord_to_parameters(record: ArrayRecord, keep_input: bool) -> Parameters:
+def arrayrecord_to_parameters(
+    record: ArrayRecord, keep_input: bool, group: str | None = None
+) -> Parameters:
     """
     Convert ArrayRecord back into Parameters.
     """
@@ -98,7 +100,7 @@ def arrayrecord_to_parameters(record: ArrayRecord, keep_input: bool) -> Paramete
     # LOG TEMPI REALI
     total_time = total_deser_time + total_decrypt_time
     crypto_impact = (total_decrypt_time / total_time * 100.0) if total_time > 0 else 0.0
-    log_file.add_crypto_time(total_decrypt_time, total_deser_time)
+    log_file.add_crypto_time(total_decrypt_time, total_deser_time, group=group)
     log_time(
         "CRYPTO STATUS: enabled=%s method=%s | DESERIALIZE: %.5f s | CRYPTO: %.5f s | TOTAL: %.5f s | IMPACT: %.2f%%",
         ENCRYPTION_ENABLED,
@@ -111,7 +113,9 @@ def arrayrecord_to_parameters(record: ArrayRecord, keep_input: bool) -> Paramete
 
     return parameters
 
-def parameters_to_arrayrecord(parameters: Parameters, keep_input: bool) -> ArrayRecord:
+def parameters_to_arrayrecord(
+    parameters: Parameters, keep_input: bool, group: str | None = None
+) -> ArrayRecord:
 
     tensor_type = parameters.tensor_type
     num_arrays = len(parameters.tensors)
@@ -160,7 +164,7 @@ def parameters_to_arrayrecord(parameters: Parameters, keep_input: bool) -> Array
     # LOG
     total_time = tot_serial_time + tot_crypto_time
     crypto_impact = (tot_crypto_time / total_time * 100.0) if total_time > 0 else 0.0
-    log_file.add_crypto_time(tot_crypto_time, tot_serial_time)
+    log_file.add_crypto_time(tot_crypto_time, tot_serial_time, group=group)
     log_time(
         "CRYPTO STATUS: enabled=%s method=%s | SERIALIZE: %.5f s | CRYPTO: %.5f s | TOTAL: %.5f s | IMPACT: %.2f%%",
         ENCRYPTION_ENABLED,
@@ -199,7 +203,10 @@ def _recorddict_to_fit_or_evaluate_ins_components(
     # get Array and construct Parameters
     array_record = recorddict.array_records[f"{ins_str}.parameters"]
 
-    parameters = arrayrecord_to_parameters(array_record, keep_input=keep_input)
+    group = "fit" if ins_str.startswith("fit") else "evaluate"
+    parameters = arrayrecord_to_parameters(
+        array_record, keep_input=keep_input, group=group
+    )
 
     # get config dict
     config_record = recorddict.config_records[f"{ins_str}.config"]
@@ -215,7 +222,8 @@ def _fit_or_evaluate_ins_to_recorddict(
     recorddict = RecordDict()
 
     ins_str = "fitins" if isinstance(ins, FitIns) else "evaluateins"
-    arr_record = parameters_to_arrayrecord(ins.parameters, keep_input)
+    group = "fit" if ins_str.startswith("fit") else "evaluate"
+    arr_record = parameters_to_arrayrecord(ins.parameters, keep_input, group=group)
     recorddict.array_records[f"{ins_str}.parameters"] = arr_record
 
     recorddict.config_records[f"{ins_str}.config"] = ConfigRecord(
@@ -274,7 +282,9 @@ def recorddict_to_fitres(recorddict: RecordDict, keep_input: bool) -> FitRes:
     ins_str = "fitres"
 
     parameters = arrayrecord_to_parameters(
-        recorddict.array_records[f"{ins_str}.parameters"], keep_input=keep_input
+        recorddict.array_records[f"{ins_str}.parameters"],
+        keep_input=keep_input,
+        group="fit",
     )
 
     num_examples = cast(
@@ -306,6 +316,7 @@ def fitres_to_recorddict(fitres: FitRes, keep_input: bool) -> RecordDict:
     recorddict.array_records[f"{res_str}.parameters"] = parameters_to_arrayrecord(
         fitres.parameters,
         keep_input,
+        group="fit",
     )
     from .crypto.utils import log_serialization_size
     log_serialization_size(recorddict, tag="fitres", mtu=1500)
@@ -407,7 +418,7 @@ def getparametersres_to_recorddict(
     recorddict = RecordDict()
     res_str = "getparametersres"
     array_record = parameters_to_arrayrecord(
-        getparametersres.parameters, keep_input=keep_input
+        getparametersres.parameters, keep_input=keep_input, group="getparameters"
     )
     recorddict.array_records[f"{res_str}.parameters"] = array_record
 
@@ -425,7 +436,9 @@ def recorddict_to_getparametersres(
     """Derive GetParametersRes from a RecordDict object."""
     res_str = "getparametersres"
     parameters = arrayrecord_to_parameters(
-        recorddict.array_records[f"{res_str}.parameters"], keep_input=keep_input
+        recorddict.array_records[f"{res_str}.parameters"],
+        keep_input=keep_input,
+        group="getparameters",
     )
 
     status = _extract_status_from_recorddict(res_str, recorddict)

--- a/framework/py/flwr/server/server.py
+++ b/framework/py/flwr/server/server.py
@@ -149,6 +149,7 @@ class Server:
 
         # Run federated learning for num_rounds
         prev_crypto_total, _ = log_file.get_crypto_totals()
+        prev_crypto_groups = log_file.get_crypto_totals_by_group()
 
         for current_round in range(1, num_rounds + 1):
             if getattr(self.strategy, "stop_triggered", False):
@@ -215,16 +216,41 @@ class Server:
             current_crypto_total, _ = log_file.get_crypto_totals()
             round_crypto_time = max(current_crypto_total - prev_crypto_total, 0.0)
             prev_crypto_total = current_crypto_total
-            parallel_factor = max(round_fit_parallel, round_eval_parallel, 1)
+
+            current_crypto_groups = log_file.get_crypto_totals_by_group()
+            round_crypto_fit = max(
+                current_crypto_groups.get("fit", (0.0, 0.0))[0]
+                - prev_crypto_groups.get("fit", (0.0, 0.0))[0],
+                0.0,
+            )
+            round_crypto_eval = max(
+                current_crypto_groups.get("evaluate", (0.0, 0.0))[0]
+                - prev_crypto_groups.get("evaluate", (0.0, 0.0))[0],
+                0.0,
+            )
+            round_crypto_other = max(
+                round_crypto_time - round_crypto_fit - round_crypto_eval, 0.0
+            )
+            prev_crypto_groups = current_crypto_groups
+
+            parallel_fit_factor = max(round_fit_parallel, 1)
+            parallel_eval_factor = max(round_eval_parallel, 1)
+            parallel_fit_crypto = round_crypto_fit / parallel_fit_factor
+            parallel_eval_crypto = round_crypto_eval / parallel_eval_factor
             parallel_crypto_time = min(
-                round_crypto_time / parallel_factor, round_elapsed
+                parallel_fit_crypto + parallel_eval_crypto + round_crypto_other,
+                round_elapsed,
             )
             without_crypto = max(round_elapsed - parallel_crypto_time, 0.0)
+            parallel_factor = max(round_fit_parallel, round_eval_parallel, 1)
             log_file.ROUND_SUMMARIES.append({
                 "round": current_round,
                 "round_time": round_elapsed,
                 "crypto_time": parallel_crypto_time,
                 "crypto_cumulative": round_crypto_time,
+                "crypto_fit": parallel_fit_crypto,
+                "crypto_eval": parallel_eval_crypto,
+                "crypto_other": round_crypto_other,
                 "parallel_fit": float(round_fit_parallel),
                 "parallel_eval": float(round_eval_parallel),
                 "parallel_factor": float(parallel_factor),


### PR DESCRIPTION
### Motivation
- Provide a more scientific, phase-aware breakdown of crypto and serialization overhead to better estimate: total round time, time spent in crypto (accounting for real parallelism), and the residual non-crypto time.
- Reduce distortions when computing `total - crypto` by attributing crypto cost per phase (`fit` / `evaluate` / `other`) and applying phase-specific parallelism adjustments.

### Description
- Track per-phase crypto/serialization totals and expose accessors by adding `TOTAL_*_BY_GROUP`, `get_crypto_totals(group)`, and `get_crypto_totals_by_group()` in `framework/py/flwr/common/crypto/log_file.py` and extend `add_crypto_time()` with a `group` parameter.
- Propagate phase labels when converting between `RecordDict` and `Parameters` by adding `group` arguments to `arrayrecord_to_parameters()` and `parameters_to_arrayrecord()` and invoking `log_file.add_crypto_time(..., group=...)` in `framework/py/flwr/common/recorddict_compat.py` for `fit`, `evaluate`, and `getparameters` flows.
- Compute a per-round crypto breakdown in `framework/py/flwr/server/server.py` by reading group totals, deriving `round_crypto_fit`, `round_crypto_eval`, and `round_crypto_other`, applying separate parallelism factors for `fit` and `evaluate`, and storing the phase breakdown (`crypto_fit`, `crypto_eval`, `crypto_other`) in `log_file.ROUND_SUMMARIES`.
- Extend the human-readable round report in `log_file.build_round_time_report()` to include per-phase crypto entries and a summary line `Totale critto per fase: fit=... | evaluate=... | other=...` when applicable.

### Testing
- Automated tests: none executed as part of this change (no test run requested).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6971c1555a488332865d6343470e1d64)