### PR TITLE
Enable Koblitz ECC auth key generation via start config

### DIFF
--- a/framework/py/flwr/common/crypto/algorithms/KOBLITZ.py
+++ b/framework/py/flwr/common/crypto/algorithms/KOBLITZ.py
@@ -1,13 +1,17 @@
-"""Implementazioni semplificate di curve di Koblitz per la demo."""
+"""Implementazioni semplificate di curve di Koblitz per la demo.
+
+Questo modulo fornisce solo generazione chiavi e autenticazione (firma/verifica).
+Non espone funzioni di cifratura.
+"""
 
 from __future__ import annotations
 
-import os
 from dataclasses import dataclass
 from typing import Dict
 
-from cryptography.hazmat.primitives import hashes, hmac
-from cryptography.hazmat.primitives.kdf.hkdf import HKDF
+from cryptography.exceptions import InvalidSignature
+from cryptography.hazmat.primitives import hashes, serialization
+from cryptography.hazmat.primitives.asymmetric import ec
 
 
 @dataclass(frozen=True)
@@ -15,17 +19,19 @@ class KoblitzCurve:
     """Definizione di una curva di Koblitz gestita dall'applicazione."""
 
     name: str
-    key_size_bits: int
+    curve: ec.EllipticCurve
 
     @property
     def key_size_bytes(self) -> int:
-        return (self.key_size_bits + 7) // 8
+        return (self.curve.key_size + 7) // 8
 
 
 SUPPORTED_CURVES: Dict[str, KoblitzCurve] = {
-    "KOBLITZ_SMALL": KoblitzCurve("KOBLITZ_SMALL", 112),
-    "KOBLITZ_MEDIUM": KoblitzCurve("KOBLITZ_MEDIUM", 256),
-    "KOBLITZ_LARGE": KoblitzCurve("KOBLITZ_LARGE", 512),
+    # Le dimensioni originali (112/256/512) sono mappate a curve supportate
+    # da cryptography per la demo.
+    "KOBLITZ_SMALL": KoblitzCurve("KOBLITZ_SMALL", ec.SECP192R1()),
+    "KOBLITZ_MEDIUM": KoblitzCurve("KOBLITZ_MEDIUM", ec.SECP256K1()),
+    "KOBLITZ_LARGE": KoblitzCurve("KOBLITZ_LARGE", ec.SECP521R1()),
 }
 
 LEGACY_ALIASES: Dict[str, str] = {
@@ -49,48 +55,50 @@ def is_supported_method(curve_name: str) -> bool:
     return curve_name in SUPPORTED_METHODS
 
 
-def _derive_keystream(curve: KoblitzCurve, secret: bytes, length: int) -> bytes:
-    hkdf = HKDF(
-        algorithm=hashes.SHA256(),
-        length=32,
-        salt=None,
-        info=curve.name.encode(),
+def _ensure_curve_matches(curve: KoblitzCurve, key_curve: ec.EllipticCurve) -> None:
+    if key_curve.name != curve.curve.name:
+        raise ValueError(
+            "La chiave non corrisponde alla curva selezionata: "
+            f"attesa {curve.curve.name}, trovata {key_curve.name}"
+        )
+
+
+def generate_keypair(curve_name: str) -> tuple[bytes, bytes]:
+    """Genera una coppia di chiavi (privata, pubblica) in formato PEM."""
+
+    curve = _get_curve(curve_name)
+    private_key = ec.generate_private_key(curve.curve)
+    private_pem = private_key.private_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PrivateFormat.PKCS8,
+        encryption_algorithm=serialization.NoEncryption(),
     )
-    prk = hkdf.derive(secret)
-    keystream = bytearray()
-    counter = 1
-    while len(keystream) < length:
-        hmac_ctx = hmac.HMAC(prk, hashes.SHA256())
-        hmac_ctx.update(counter.to_bytes(4, "big"))
-        keystream.extend(hmac_ctx.finalize())
-        counter += 1
-    return bytes(keystream[:length])
+    public_pem = private_key.public_key().public_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PublicFormat.SubjectPublicKeyInfo,
+    )
+    return private_pem, public_pem
 
 
-def encrypt(data: bytes, curve_name: str) -> bytes:
-    """Cifra i dati utilizzando una curva di Koblitz simulata.
-
-    La funzione genera un segreto effimero della dimensione della curva
-    (112/256/512 bit) e lo usa per derivare un keystream tramite HKDF. Il
-    keystream viene poi combinato con i dati tramite XOR. Il segreto viene
-    prefissato al ciphertext per consentire la decifratura.
-    """
-
+def sign(data: bytes, private_key_pem: bytes, curve_name: str) -> bytes:
+    """Firma i dati con la chiave privata usando ECDSA."""
     curve = _get_curve(curve_name)
-    secret = os.urandom(curve.key_size_bytes)
-    keystream = _derive_keystream(curve, secret, len(data))
-    ciphertext = bytes(d ^ k for d, k in zip(data, keystream))
-    return secret + ciphertext
+    private_key = serialization.load_pem_private_key(private_key_pem, password=None)
+    if not isinstance(private_key, ec.EllipticCurvePrivateKey):
+        raise TypeError("Chiave privata non valida per ECDSA")
+    _ensure_curve_matches(curve, private_key.curve)
+    return private_key.sign(data, ec.ECDSA(hashes.SHA256()))
 
 
-def decrypt(encrypted_data: bytes, curve_name: str) -> bytes:
-    """Decifra i dati protetti con :func:`encrypt`."""
-
+def verify(data: bytes, signature: bytes, public_key_pem: bytes, curve_name: str) -> bool:
+    """Verifica la firma ECDSA usando la chiave pubblica."""
     curve = _get_curve(curve_name)
-    if len(encrypted_data) < curve.key_size_bytes:
-        raise ValueError("Dati cifrati troppo corti per la curva scelta")
-
-    secret = encrypted_data[: curve.key_size_bytes]
-    ciphertext = encrypted_data[curve.key_size_bytes :]
-    keystream = _derive_keystream(curve, secret, len(ciphertext))
-    return bytes(c ^ k for c, k in zip(ciphertext, keystream))
+    public_key = serialization.load_pem_public_key(public_key_pem)
+    if not isinstance(public_key, ec.EllipticCurvePublicKey):
+        raise TypeError("Chiave pubblica non valida per ECDSA")
+    _ensure_curve_matches(curve, public_key.curve)
+    try:
+        public_key.verify(signature, data, ec.ECDSA(hashes.SHA256()))
+    except InvalidSignature:
+        return False
+    return True

--- a/framework/py/flwr/common/crypto/crypto_selector.py
+++ b/framework/py/flwr/common/crypto/crypto_selector.py
@@ -13,7 +13,10 @@ def encrypt(data: bytes, method: str, ecc_pubkey=None) -> bytes:
     elif method == "AES_GCM":
         return AES_GCM.encrypt(data)
     elif KOBLITZ.is_supported_method(method):
-        return KOBLITZ.encrypt(data, method)
+        raise ValueError(
+            "Il metodo KOBLITZ supporta solo generazione chiavi e autenticazione, "
+            "non la cifratura dei dati."
+        )
     else:
         raise ValueError(f"Unknown encryption method: {method}")
 
@@ -30,7 +33,10 @@ def decrypt(data: bytes, method: str, ecc_privkey=None) -> bytes:
     elif method == "AES_GCM":
         return AES_GCM.decrypt(data)
     elif KOBLITZ.is_supported_method(method):
-        return KOBLITZ.decrypt(data, method)
+        raise ValueError(
+            "Il metodo KOBLITZ supporta solo generazione chiavi e autenticazione, "
+            "non la decifratura dei dati."
+        )
     else:
         raise ValueError(f"Unknown decryption method: {method}")
 
@@ -45,5 +51,4 @@ def check_integrity(data: bytes, method: str) -> bytes:
         return HMAC.check_hmac(data)
     else:
         raise ValueError(f"Unknown integrity method: {method}")
-
 

--- a/framework/py/flwr/common/crypto/start.py
+++ b/framework/py/flwr/common/crypto/start.py
@@ -2,6 +2,8 @@
 
 import os
 
+from flwr.common.crypto.algorithms import KOBLITZ
+
 CONFIG_FILE = "config_cripto.py"
 
 # Opzioni disponibili
@@ -10,11 +12,13 @@ ENCRYPTION_METHODS = [
     "CHACHA",
     "CHACHA_AEAD",
     "AES_GCM",
+]
+INTEGRITY_METHODS = ["HMAC"]
+AUTH_METHODS = [
     "KOBLITZ_SMALL",
     "KOBLITZ_MEDIUM",
     "KOBLITZ_LARGE",
 ]
-INTEGRITY_METHODS = ["HMAC"]
 NET_OPTIONS = ["custom_cnn", "resnet18", "resnet34", "tiny_cnn", "squeezenet"]
 EVALUATION_OPTIONS = ["server", "client"]
 
@@ -75,6 +79,22 @@ def ask_choice(prompt, options, default=None):
             return val
         print(f"Valore non valido, scegli tra: {options_str}")
 
+def _ensure_parent_dir(path: str) -> None:
+    parent = os.path.dirname(path)
+    if parent:
+        os.makedirs(parent, exist_ok=True)
+
+def _write_auth_keys(
+    curve_name: str, private_key_path: str, public_key_path: str
+) -> None:
+    private_key, public_key = KOBLITZ.generate_keypair(curve_name)
+    _ensure_parent_dir(private_key_path)
+    _ensure_parent_dir(public_key_path)
+    with open(private_key_path, "wb") as private_file:
+        private_file.write(private_key)
+    with open(public_key_path, "wb") as public_file:
+        public_file.write(public_key)
+
 # Carica configurazione esistente se presente
 def load_existing_config():
     config = {}
@@ -104,6 +124,33 @@ def configure():
         INTEGRITY_METHOD = ask_choice("Metodo di integrità", INTEGRITY_METHODS,
                                       existing.get('INTEGRITY_METHOD', "HMAC"))
 
+    # Autenticazione con curve ellittiche
+    AUTH_ENABLED = ask_bool(
+        "Abilitare autenticazione con curve ellittiche?",
+        existing.get("AUTH_ENABLED", False),
+    )
+    AUTH_METHOD = None
+    AUTH_PRIVATE_KEY_PATH = None
+    AUTH_PUBLIC_KEY_PATH = None
+    if AUTH_ENABLED:
+        AUTH_METHOD = ask_choice(
+            "Metodo di autenticazione (curve)",
+            AUTH_METHODS,
+            existing.get("AUTH_METHOD", "KOBLITZ_MEDIUM"),
+        )
+        AUTH_PRIVATE_KEY_PATH = ask_string(
+            "Percorso chiave privata",
+            existing.get("AUTH_PRIVATE_KEY_PATH", "auth_private_key.pem"),
+        )
+        AUTH_PUBLIC_KEY_PATH = ask_string(
+            "Percorso chiave pubblica",
+            existing.get("AUTH_PUBLIC_KEY_PATH", "auth_public_key.pem"),
+        )
+        if ask_bool("Generare nuove chiavi di autenticazione?", True):
+            _write_auth_keys(
+                AUTH_METHOD, AUTH_PRIVATE_KEY_PATH, AUTH_PUBLIC_KEY_PATH
+            )
+
     # Rete e altri parametri
     NET = ask_choice("Tipo di rete", NET_OPTIONS, existing.get('NET', "resnet18"))
     TLS = ask_bool("Attivo TLS?", existing.get('TLS', False))
@@ -122,6 +169,10 @@ def configure():
         f.write(f"ENCRYPTION_METHOD = {repr(ENCRYPTION_METHOD)}\n")
         f.write(f"INTEGRITY_ENABLED = {INTEGRITY_ENABLED}\n")
         f.write(f"INTEGRITY_METHOD = {repr(INTEGRITY_METHOD)}\n")
+        f.write(f"AUTH_ENABLED = {AUTH_ENABLED}\n")
+        f.write(f"AUTH_METHOD = {repr(AUTH_METHOD)}\n")
+        f.write(f"AUTH_PRIVATE_KEY_PATH = {repr(AUTH_PRIVATE_KEY_PATH)}\n")
+        f.write(f"AUTH_PUBLIC_KEY_PATH = {repr(AUTH_PUBLIC_KEY_PATH)}\n")
         f.write(f"NET = '{NET}'\n")
         f.write(f"TLS = {TLS}\n")
         f.write(f"ACCURACY = {ACCURACY}\n")


### PR DESCRIPTION
### Motivation
- Make it possible to enable and provision the KOBLITZ-based ECC authentication flow from the interactive start script now that KOBLITZ only provides keygen/sign/verify.
- Provide a simple UX to choose a Koblitz curve, set private/public key file paths, and generate PEM keypairs for node/client authentication.

### Description
- Added interactive ECC auth options to `framework/py/flwr/common/crypto/start.py`, including new prompts for `AUTH_ENABLED`, `AUTH_METHOD`, `AUTH_PRIVATE_KEY_PATH`, and `AUTH_PUBLIC_KEY_PATH` and persistence to the `CONFIG_FILE`.
- Implemented helper functions `_ensure_parent_dir` and `_write_auth_keys` in `start.py` and imported `KOBLITZ` to call `KOBLITZ.generate_keypair(curve_name)` and write PEM files.
- Kept prior changes that convert `KOBLITZ` to key management/auth only by raising explicit errors in `crypto_selector.py` when `KOBLITZ` is (mis)used for `encrypt`/`decrypt`, and by providing `generate_keypair`, `sign`, and `verify` in `KOBLITZ.py`.

### Testing
- No automated tests were run for these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697250d851348332b10a209ca8462935)