### PR TITLE
Support PEM EC keys for SuperNode auth and add timing logs for Koblitz ECDSA ops

### DIFF
--- a/framework/py/flwr/common/crypto/algorithms/KOBLITZ.py
+++ b/framework/py/flwr/common/crypto/algorithms/KOBLITZ.py
@@ -7,11 +7,15 @@ Non espone funzioni di cifratura.
 from __future__ import annotations
 
 from dataclasses import dataclass
+import logging
+import time
 from typing import Dict
 
 from cryptography.exceptions import InvalidSignature
 from cryptography.hazmat.primitives import hashes, serialization
 from cryptography.hazmat.primitives.asymmetric import ec
+
+logger = logging.getLogger(__name__)
 
 
 @dataclass(frozen=True)
@@ -66,6 +70,7 @@ def _ensure_curve_matches(curve: KoblitzCurve, key_curve: ec.EllipticCurve) -> N
 def generate_keypair(curve_name: str) -> tuple[bytes, bytes]:
     """Genera una coppia di chiavi (privata, pubblica) in formato PEM."""
 
+    start_time = time.perf_counter()
     curve = _get_curve(curve_name)
     private_key = ec.generate_private_key(curve.curve)
     private_pem = private_key.private_bytes(
@@ -77,21 +82,36 @@ def generate_keypair(curve_name: str) -> tuple[bytes, bytes]:
         encoding=serialization.Encoding.PEM,
         format=serialization.PublicFormat.SubjectPublicKeyInfo,
     )
+    elapsed = time.perf_counter() - start_time
+    logger.info(
+        "KOBLITZ keypair generated (curve=%s, elapsed=%.6f s)",
+        curve.name,
+        elapsed,
+    )
     return private_pem, public_pem
 
 
 def sign(data: bytes, private_key_pem: bytes, curve_name: str) -> bytes:
     """Firma i dati con la chiave privata usando ECDSA."""
+    start_time = time.perf_counter()
     curve = _get_curve(curve_name)
     private_key = serialization.load_pem_private_key(private_key_pem, password=None)
     if not isinstance(private_key, ec.EllipticCurvePrivateKey):
         raise TypeError("Chiave privata non valida per ECDSA")
     _ensure_curve_matches(curve, private_key.curve)
-    return private_key.sign(data, ec.ECDSA(hashes.SHA256()))
+    signature = private_key.sign(data, ec.ECDSA(hashes.SHA256()))
+    elapsed = time.perf_counter() - start_time
+    logger.info(
+        "KOBLITZ signature created (curve=%s, elapsed=%.6f s)",
+        curve.name,
+        elapsed,
+    )
+    return signature
 
 
 def verify(data: bytes, signature: bytes, public_key_pem: bytes, curve_name: str) -> bool:
     """Verifica la firma ECDSA usando la chiave pubblica."""
+    start_time = time.perf_counter()
     curve = _get_curve(curve_name)
     public_key = serialization.load_pem_public_key(public_key_pem)
     if not isinstance(public_key, ec.EllipticCurvePublicKey):
@@ -100,5 +120,17 @@ def verify(data: bytes, signature: bytes, public_key_pem: bytes, curve_name: str
     try:
         public_key.verify(signature, data, ec.ECDSA(hashes.SHA256()))
     except InvalidSignature:
+        elapsed = time.perf_counter() - start_time
+        logger.info(
+            "KOBLITZ signature rejected (curve=%s, elapsed=%.6f s)",
+            curve.name,
+            elapsed,
+        )
         return False
+    elapsed = time.perf_counter() - start_time
+    logger.info(
+        "KOBLITZ signature verified (curve=%s, elapsed=%.6f s)",
+        curve.name,
+        elapsed,
+    )
     return True

--- a/framework/py/flwr/supernode/cli/flower_supernode.py
+++ b/framework/py/flwr/supernode/cli/flower_supernode.py
@@ -23,6 +23,8 @@ from typing import Optional
 from cryptography.exceptions import UnsupportedAlgorithm
 from cryptography.hazmat.primitives.asymmetric import ec
 from cryptography.hazmat.primitives.serialization import (
+    load_pem_private_key,
+    load_pem_public_key,
     load_ssh_private_key,
     load_ssh_public_key,
 )
@@ -210,32 +212,42 @@ def _try_setup_client_authentication(
     if not args.auth_supernode_private_key or not args.auth_supernode_public_key:
         flwr_exit(ExitCode.SUPERNODE_NODE_AUTH_KEYS_REQUIRED)
 
-    try:
-        ssh_private_key = load_ssh_private_key(
-            Path(args.auth_supernode_private_key).read_bytes(),
-            None,
-        )
-        if not isinstance(ssh_private_key, ec.EllipticCurvePrivateKey):
-            raise ValueError()
-    except (ValueError, UnsupportedAlgorithm):
-        flwr_exit(
-            ExitCode.SUPERNODE_NODE_AUTH_KEYS_INVALID,
-            "Unable to parse the private key file.",
-        )
+    private_key_bytes = Path(args.auth_supernode_private_key).read_bytes()
+    public_key_bytes = Path(args.auth_supernode_public_key).read_bytes()
 
-    try:
-        ssh_public_key = load_ssh_public_key(
-            Path(args.auth_supernode_public_key).read_bytes()
-        )
-        if not isinstance(ssh_public_key, ec.EllipticCurvePublicKey):
-            raise ValueError()
-    except (ValueError, UnsupportedAlgorithm):
-        flwr_exit(
-            ExitCode.SUPERNODE_NODE_AUTH_KEYS_INVALID,
-            "Unable to parse the public key file.",
-        )
+    private_key = _load_ec_private_key(private_key_bytes)
+    public_key = _load_ec_public_key(public_key_bytes)
 
-    return (
-        ssh_private_key,
-        ssh_public_key,
+    return (private_key, public_key)
+
+
+def _load_ec_private_key(key_bytes: bytes) -> ec.EllipticCurvePrivateKey:
+    for loader in (load_ssh_private_key, load_pem_private_key):
+        try:
+            key = loader(key_bytes, password=None)
+        except (ValueError, UnsupportedAlgorithm, TypeError):
+            continue
+        if isinstance(key, ec.EllipticCurvePrivateKey):
+            return key
+
+    flwr_exit(
+        ExitCode.SUPERNODE_NODE_AUTH_KEYS_INVALID,
+        "Unable to parse the private key file.",
     )
+    raise RuntimeError("Unreachable private key parser")
+
+
+def _load_ec_public_key(key_bytes: bytes) -> ec.EllipticCurvePublicKey:
+    for loader in (load_ssh_public_key, load_pem_public_key):
+        try:
+            key = loader(key_bytes)
+        except (ValueError, UnsupportedAlgorithm, TypeError):
+            continue
+        if isinstance(key, ec.EllipticCurvePublicKey):
+            return key
+
+    flwr_exit(
+        ExitCode.SUPERNODE_NODE_AUTH_KEYS_INVALID,
+        "Unable to parse the public key file.",
+    )
+    raise RuntimeError("Unreachable public key parser")


### PR DESCRIPTION
### Motivation
- Allow SuperNode node-auth keys generated as PEM (e.g. Koblitz/EC PEM keys) to be loaded in addition to SSH-format keys so Koblitz-produced keys can be used for client/server authentication.
- Factor key parsing into reusable helpers to centralize EC key loading and error handling.
- Record runtime metrics for the demo Koblitz ECDSA operations to observe latencies for keygen, sign and verify.

### Description
- Updated `framework/py/flwr/supernode/cli/flower_supernode.py` to accept PEM-encoded EC private/public keys by importing `load_pem_private_key` and `load_pem_public_key` and adding helpers `_load_ec_private_key` and `_load_ec_public_key` that try SSH loaders first and then PEM loaders, returning typed `ec` keys or exiting with `ExitCode.SUPERNODE_NODE_AUTH_KEYS_INVALID` on failure.
- Replaced the previous strict SSH-only parsing in `_try_setup_client_authentication` to read the key files as bytes and delegate to the new loaders, returning `(private_key, public_key)` when successful.
- Updated `framework/py/flwr/common/crypto/algorithms/KOBLITZ.py` to import `logging` and `time`, create a module `logger`, and add `time.perf_counter()` timers plus informational logs to `generate_keypair`, `sign`, and `verify` that include curve name and elapsed time; behavior of signature generation/verification remains unchanged beyond logging.

### Testing
- No automated tests were run for these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6973d6dde1348332b95fcda59a77740d)