### PR TITLE
Support PEM/SSH EC keys and make auth example client count configurable

### DIFF
--- a/examples/flower-authentication/README.md
+++ b/examples/flower-authentication/README.md
@@ -62,7 +62,12 @@ The `generate_cert.sh` script generates certificates for creating a secure TLS c
 
 ## Generate public and private keys for SuperNode authentication
 
-The `generate_auth_keys.sh` script generates three private and public key pairs. One pair for the SuperLink and two pairs for the two SuperNodes.
+The `generate_auth_keys.sh` script generates two private/public key pairs by default,
+cycling through three curve sizes for authentication:
+
+- **Small (112-bit)**: `secp112r1` (closest available 112-bit curve in OpenSSL)
+- **Medium (256-bit)**: `secp256k1`
+- **Large (512-bit)**: `sect571k1` (closest available Koblitz curve in OpenSSL)
 
 > [!NOTE]
 > Note that this script should only be used for development purposes and not for creating production key pairs.
@@ -72,7 +77,8 @@ The `generate_auth_keys.sh` script generates three private and public key pairs.
 ```
 
 You can generate more keys by specifying the number of client credentials that you wish to generate.
-The script also generates a CSV file that includes each of the generated (client) public keys.
+The script also generates a CSV file that includes each of the generated (client) public keys as
+base64-encoded PEM strings.
 
 ```bash
 ./generate_auth_keys.sh {your_number_of_clients}
@@ -109,7 +115,7 @@ In a new terminal window, start the first long-running Flower client (SuperNode)
 ```bash
 flower-supernode \
     --root-certificates certificates/ca.crt \
-    --auth-supernode-private-key keys/client_credentials_1 \
+    --auth-supernode-private-key keys/client_credentials_1.key \
     --auth-supernode-public-key keys/client_credentials_1.pub \
     --node-config 'dataset-path="datasets/cifar10_part_1"' \
     --clientappio-api-address="0.0.0.0:9094"
@@ -120,14 +126,14 @@ In yet another new terminal window, start the second long-running Flower client:
 ```bash
 flower-supernode \
     --root-certificates certificates/ca.crt \
-    --auth-supernode-private-key keys/client_credentials_2 \
+    --auth-supernode-private-key keys/client_credentials_2.key \
     --auth-supernode-public-key keys/client_credentials_2.pub \
     --node-config 'dataset-path="datasets/cifar10_part_2"' \
     --clientappio-api-address="0.0.0.0:9095"
 ```
 
 If you generated more than 2 client credentials, you can add more clients by opening new terminal windows and running the command
-above. Don't forget to specify the correct client private and public keys for each client instance you created.
+above, incrementing the dataset path and port, and matching the correct key pair for each client instance you created.
 
 > [!TIP]
 > Note the `--node-config` passed when spawning the `SuperNode` is accessible to the `ClientApp` via the context. In this example, the `client_fn()` uses it to load the dataset and then proceed with the training of the model.

--- a/examples/flower-authentication/generate_auth_keys.sh
+++ b/examples/flower-authentication/generate_auth_keys.sh
@@ -11,19 +11,34 @@ mkdir -p $KEY_DIR
 
 rm -f $KEY_DIR/*
 
+CURVES=("secp112r1" "secp256k1" "sect571k1")
+SIZES=("112" "256" "512")
+
 generate_client_credentials() {
-    local num_clients=${1:-2} 
+    local num_clients=${1:-2}
     for ((i=1; i<=num_clients; i++))
     do
-        ssh-keygen -t ecdsa -b 384 -N "" -f "${KEY_DIR}/client_credentials_$i" -C ""
+        local curve_index=$(( (i - 1) % ${#CURVES[@]} ))
+        local curve_name=${CURVES[$curve_index]}
+        local curve_size=${SIZES[$curve_index]}
+
+        echo "[*] Generating client $i with curve ${curve_name} (${curve_size}-bit)"
+        openssl ecparam -name "$curve_name" -genkey -noout \
+            -out "${KEY_DIR}/client_credentials_${i}.key"
+        openssl ec -in "${KEY_DIR}/client_credentials_${i}.key" -pubout \
+            -out "${KEY_DIR}/client_credentials_${i}.pub"
     done
 }
 
 generate_client_credentials "$1"
 
-printf "%s" "$(cat "${KEY_DIR}/client_credentials_1.pub" | sed 's/.$//')" > $KEY_DIR/client_public_keys.csv
-for ((i=2; i<=${1:-2}; i++))
+for ((i=1; i<=${1:-2}; i++))
 do
-    printf ",%s" "$(sed 's/.$//' < "${KEY_DIR}/client_credentials_$i.pub")" >> $KEY_DIR/client_public_keys.csv
+    entry="$(openssl base64 -A -in "${KEY_DIR}/client_credentials_${i}.pub")"
+    if [ "$i" -eq 1 ]; then
+        printf "%s" "$entry" > $KEY_DIR/client_public_keys.csv
+    else
+        printf ",%s" "$entry" >> $KEY_DIR/client_public_keys.csv
+    fi
 done
 printf "\n" >> $KEY_DIR/client_public_keys.csv

--- a/examples/flower-authentication/start_clients.sh
+++ b/examples/flower-authentication/start_clients.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-NUM_CLIENTS=2
+NUM_CLIENTS=${NUM_CLIENTS:-2}
 
 # 1. Genera tutte le chiavi in un colpo solo
 
@@ -9,7 +9,7 @@ NUM_CLIENTS=2
 for i in $(seq 1 $NUM_CLIENTS); do
     PORT=$((9093 + i))
     DATASET="datasets/cifar10_part_$i"
-    PRIV_KEY="keys/client_credentials_${i}"
+    PRIV_KEY="keys/client_credentials_${i}.key"
     PUB_KEY="keys/client_credentials_${i}.pub"
 
     flower-supernode \

--- a/framework/py/flwr/server/app.py
+++ b/framework/py/flwr/server/app.py
@@ -17,6 +17,8 @@
 
 import argparse
 import csv
+from base64 import b64decode
+from binascii import Error as BinasciiError
 import importlib.util
 import os
 import subprocess
@@ -30,8 +32,12 @@ from typing import Any, Callable, Optional, TypeVar
 
 import grpc
 import yaml
+from cryptography.exceptions import UnsupportedAlgorithm
 from cryptography.hazmat.primitives.asymmetric import ec
-from cryptography.hazmat.primitives.serialization import load_ssh_public_key
+from cryptography.hazmat.primitives.serialization import (
+    load_pem_public_key,
+    load_ssh_public_key,
+)
 
 from flwr.common import GRPC_MAX_MESSAGE_LENGTH, EventType, event
 from flwr.common.address import parse_address
@@ -408,16 +414,57 @@ def _try_load_public_keys_node_authentication(
         reader = csv.reader(csvfile)
         for row in reader:
             for element in row:
-                public_key = load_ssh_public_key(element.encode())
-                if isinstance(public_key, ec.EllipticCurvePublicKey):
-                    node_public_keys.add(public_key_to_bytes(public_key))
-                else:
+                try:
+                    public_key = _load_node_public_key(element)
+                except (ValueError, UnsupportedAlgorithm):
                     sys.exit(
                         "Error: Unable to parse the public keys in the CSV "
                         "file. Please ensure that the CSV file path points to a valid "
-                        "known SSH public keys files and try again."
+                        "known SSH or PEM public keys file and try again."
                     )
+                node_public_keys.add(public_key_to_bytes(public_key))
     return node_public_keys
+
+
+def _load_node_public_key(element: str) -> ec.EllipticCurvePublicKey:
+    raw_entry = element.strip()
+    if not raw_entry:
+        raise ValueError("Empty public key entry")
+
+    raw_bytes = raw_entry.encode()
+    public_key = _try_load_ec_public_key(raw_bytes)
+    if public_key is not None:
+        return public_key
+
+    try:
+        decoded = b64decode(raw_entry, validate=True)
+    except (BinasciiError, ValueError):
+        decoded = None
+
+    if decoded:
+        public_key = _try_load_ec_public_key(decoded)
+        if public_key is not None:
+            return public_key
+
+    raise ValueError("Unsupported public key entry")
+
+
+def _try_load_ec_public_key(key_bytes: bytes) -> Optional[ec.EllipticCurvePublicKey]:
+    try:
+        public_key = load_ssh_public_key(key_bytes)
+        if isinstance(public_key, ec.EllipticCurvePublicKey):
+            return public_key
+    except (ValueError, UnsupportedAlgorithm):
+        pass
+
+    try:
+        public_key = load_pem_public_key(key_bytes)
+        if isinstance(public_key, ec.EllipticCurvePublicKey):
+            return public_key
+    except (ValueError, UnsupportedAlgorithm):
+        pass
+
+    return None
 
 
 def _try_obtain_control_auth_plugins(

--- a/framework/py/flwr/supernode/cli/flower_supernode.py
+++ b/framework/py/flwr/supernode/cli/flower_supernode.py
@@ -23,6 +23,8 @@ from typing import Optional
 from cryptography.exceptions import UnsupportedAlgorithm
 from cryptography.hazmat.primitives.asymmetric import ec
 from cryptography.hazmat.primitives.serialization import (
+    load_pem_private_key,
+    load_pem_public_key,
     load_ssh_private_key,
     load_ssh_public_key,
 )
@@ -211,24 +213,19 @@ def _try_setup_client_authentication(
         flwr_exit(ExitCode.SUPERNODE_NODE_AUTH_KEYS_REQUIRED)
 
     try:
-        ssh_private_key = load_ssh_private_key(
-            Path(args.auth_supernode_private_key).read_bytes(),
-            None,
+        ssh_private_key = _load_ec_private_key(
+            Path(args.auth_supernode_private_key).read_bytes()
         )
-        if not isinstance(ssh_private_key, ec.EllipticCurvePrivateKey):
-            raise ValueError()
-    except (ValueError, UnsupportedAlgorithm):
+    except (ValueError, UnsupportedAlgorithm, TypeError):
         flwr_exit(
             ExitCode.SUPERNODE_NODE_AUTH_KEYS_INVALID,
             "Unable to parse the private key file.",
         )
 
     try:
-        ssh_public_key = load_ssh_public_key(
+        ssh_public_key = _load_ec_public_key(
             Path(args.auth_supernode_public_key).read_bytes()
         )
-        if not isinstance(ssh_public_key, ec.EllipticCurvePublicKey):
-            raise ValueError()
     except (ValueError, UnsupportedAlgorithm):
         flwr_exit(
             ExitCode.SUPERNODE_NODE_AUTH_KEYS_INVALID,
@@ -239,3 +236,31 @@ def _try_setup_client_authentication(
         ssh_private_key,
         ssh_public_key,
     )
+
+
+def _load_ec_private_key(key_bytes: bytes) -> ec.EllipticCurvePrivateKey:
+    try:
+        private_key = load_ssh_private_key(key_bytes, None)
+        if isinstance(private_key, ec.EllipticCurvePrivateKey):
+            return private_key
+    except (ValueError, UnsupportedAlgorithm):
+        pass
+
+    private_key = load_pem_private_key(key_bytes, password=None)
+    if not isinstance(private_key, ec.EllipticCurvePrivateKey):
+        raise ValueError("Invalid private key type")
+    return private_key
+
+
+def _load_ec_public_key(key_bytes: bytes) -> ec.EllipticCurvePublicKey:
+    try:
+        public_key = load_ssh_public_key(key_bytes)
+        if isinstance(public_key, ec.EllipticCurvePublicKey):
+            return public_key
+    except (ValueError, UnsupportedAlgorithm):
+        pass
+
+    public_key = load_pem_public_key(key_bytes)
+    if not isinstance(public_key, ec.EllipticCurvePublicKey):
+        raise ValueError("Invalid public key type")
+    return public_key


### PR DESCRIPTION
### Motivation
- Restore a usable authentication example that defaults to two SuperNodes while allowing the client count to be configurable.  
- Accept both SSH-style and PEM-format EC keys (and base64-encoded PEM entries in CSVs) so the server and SuperNode can parse common key formats robustly.  
- Generate EC keys using OpenSSL across multiple curve sizes to preserve the original intent of testing varied curve strengths.  

### Description
- Make the auth example client count configurable by using `NUM_CLIENTS=${NUM_CLIENTS:-2}` in `examples/flower-authentication/start_clients.sh` and using a `num_partitions` default of `2` in `examples/flower-authentication/prepare_dataset.py`.  
- Update `examples/flower-authentication/generate_auth_keys.sh` to generate EC keys with OpenSSL cycling through `secp112r1`, `secp256k1`, and `sect571k1`, to emit PEM private files (`.key`) and PEM public files, and to produce a CSV of base64-encoded public PEM entries.  
- Adjust `examples/flower-authentication/README.md` to reflect the two-client default, updated filenames (`.key`), and guidance for scaling to more clients.  
- Add PEM/SSH parsing helpers to the SuperNode CLI (`framework/py/flwr/supernode/cli/flower_supernode.py`) by introducing `_load_ec_private_key` and `_load_ec_public_key` and importing `load_pem_private_key`/`load_pem_public_key`.  
- Extend server-side CSV public-key loading (`framework/py/flwr/server/app.py`) with `_load_node_public_key` and `_try_load_ec_public_key` that accept SSH public keys, PEM public keys, and base64-encoded PEM entries, and added defensive decoding/exception handling.  

### Testing
- No automated tests were executed for these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697484e65c608332abe1f701478742c6)