### PR TITLE
Add Koblitz-based authentication option and timing logs

### DIFF
--- a/framework/py/flwr/common/crypto/algorithms/KOBLITZ.py
+++ b/framework/py/flwr/common/crypto/algorithms/KOBLITZ.py
@@ -6,6 +6,7 @@ import os
 from dataclasses import dataclass
 from typing import Dict
 
+from cryptography.exceptions import InvalidSignature
 from cryptography.hazmat.primitives import hashes, hmac
 from cryptography.hazmat.primitives.kdf.hkdf import HKDF
 
@@ -94,3 +95,41 @@ def decrypt(encrypted_data: bytes, curve_name: str) -> bytes:
     ciphertext = encrypted_data[curve.key_size_bytes :]
     keystream = _derive_keystream(curve, secret, len(ciphertext))
     return bytes(c ^ k for c, k in zip(ciphertext, keystream))
+
+
+def authenticate(data: bytes, curve_name: str) -> bytes:
+    """Autentica i dati usando una curva di Koblitz simulata.
+
+    Genera un segreto effimero della dimensione della curva e calcola un tag
+    HMAC-SHA256. Il segreto viene prefissato al payload per consentire la
+    verifica.
+    """
+
+    curve = _get_curve(curve_name)
+    secret = os.urandom(curve.key_size_bytes)
+    auth_key = _derive_keystream(curve, secret, hashes.SHA256().digest_size)
+    hmac_ctx = hmac.HMAC(auth_key, hashes.SHA256())
+    hmac_ctx.update(data)
+    tag = hmac_ctx.finalize()
+    return secret + data + tag
+
+
+def verify(authenticated_data: bytes, curve_name: str) -> bytes:
+    """Verifica l'autenticazione creata da :func:`authenticate`."""
+
+    curve = _get_curve(curve_name)
+    tag_len = hashes.SHA256().digest_size
+    if len(authenticated_data) < curve.key_size_bytes + tag_len:
+        raise ValueError("Dati autenticati troppo corti per la curva scelta")
+
+    secret = authenticated_data[: curve.key_size_bytes]
+    tag = authenticated_data[-tag_len:]
+    data = authenticated_data[curve.key_size_bytes:-tag_len]
+    auth_key = _derive_keystream(curve, secret, tag_len)
+    hmac_ctx = hmac.HMAC(auth_key, hashes.SHA256())
+    hmac_ctx.update(data)
+    try:
+        hmac_ctx.verify(tag)
+    except InvalidSignature as exc:
+        raise ValueError("Autenticazione Koblitz non valida") from exc
+    return data

--- a/framework/py/flwr/common/crypto/config_cripto.py
+++ b/framework/py/flwr/common/crypto/config_cripto.py
@@ -1,0 +1,16 @@
+"""Configurazione di default per i moduli di crittografia."""
+
+ENCRYPTION_ENABLED = False
+ENCRYPTION_METHOD = None
+
+INTEGRITY_ENABLED = True
+INTEGRITY_METHOD = "HMAC"
+
+AUTH_ENABLED = False
+AUTH_METHOD = None
+
+NET = "resnet18"
+TLS = False
+ACCURACY = 0.5
+NUM_CLIENTS = 1
+EVALUATION_SIDE = "server"

--- a/framework/py/flwr/common/crypto/crypto_selector.py
+++ b/framework/py/flwr/common/crypto/crypto_selector.py
@@ -34,6 +34,20 @@ def decrypt(data: bytes, method: str, ecc_privkey=None) -> bytes:
     else:
         raise ValueError(f"Unknown decryption method: {method}")
 
+
+def authenticate(data: bytes, method: str) -> bytes:
+    if KOBLITZ.is_supported_method(method):
+        return KOBLITZ.authenticate(data, method)
+    else:
+        raise ValueError(f"Unknown authentication method: {method}")
+
+
+def verify_authentication(data: bytes, method: str) -> bytes:
+    if KOBLITZ.is_supported_method(method):
+        return KOBLITZ.verify(data, method)
+    else:
+        raise ValueError(f"Unknown authentication method: {method}")
+
 def add_integrity(data: bytes, method: str) -> bytes:
     if method == "HMAC":
         return HMAC.add_hmac(data)
@@ -45,5 +59,4 @@ def check_integrity(data: bytes, method: str) -> bytes:
         return HMAC.check_hmac(data)
     else:
         raise ValueError(f"Unknown integrity method: {method}")
-
 

--- a/framework/py/flwr/common/crypto/start.py
+++ b/framework/py/flwr/common/crypto/start.py
@@ -15,6 +15,7 @@ ENCRYPTION_METHODS = [
     "KOBLITZ_LARGE",
 ]
 INTEGRITY_METHODS = ["HMAC"]
+AUTH_METHODS = ["KOBLITZ_112", "KOBLITZ_256", "KOBLITZ_512"]
 NET_OPTIONS = ["custom_cnn", "resnet18", "resnet34", "tiny_cnn", "squeezenet"]
 EVALUATION_OPTIONS = ["server", "client"]
 
@@ -104,6 +105,13 @@ def configure():
         INTEGRITY_METHOD = ask_choice("Metodo di integrità", INTEGRITY_METHODS,
                                       existing.get('INTEGRITY_METHOD', "HMAC"))
 
+    # Autenticazione
+    AUTH_ENABLED = ask_bool("Abilitare autenticazione?", existing.get('AUTH_ENABLED', False))
+    AUTH_METHOD = None
+    if AUTH_ENABLED:
+        AUTH_METHOD = ask_choice("Metodo di autenticazione", AUTH_METHODS,
+                                 existing.get('AUTH_METHOD', "KOBLITZ_112"))
+
     # Rete e altri parametri
     NET = ask_choice("Tipo di rete", NET_OPTIONS, existing.get('NET', "resnet18"))
     TLS = ask_bool("Attivo TLS?", existing.get('TLS', False))
@@ -122,6 +130,8 @@ def configure():
         f.write(f"ENCRYPTION_METHOD = {repr(ENCRYPTION_METHOD)}\n")
         f.write(f"INTEGRITY_ENABLED = {INTEGRITY_ENABLED}\n")
         f.write(f"INTEGRITY_METHOD = {repr(INTEGRITY_METHOD)}\n")
+        f.write(f"AUTH_ENABLED = {AUTH_ENABLED}\n")
+        f.write(f"AUTH_METHOD = {repr(AUTH_METHOD)}\n")
         f.write(f"NET = '{NET}'\n")
         f.write(f"TLS = {TLS}\n")
         f.write(f"ACCURACY = {ACCURACY}\n")

--- a/framework/py/flwr/common/recorddict_compat.py
+++ b/framework/py/flwr/common/recorddict_compat.py
@@ -23,8 +23,22 @@ from typing import Union, cast, get_args
 import psutil
 
 from . import Array, ArrayRecord, ConfigRecord, MetricRecord, RecordDict
-from .crypto.crypto_selector import encrypt, decrypt, add_integrity, check_integrity
-from .crypto.config_cripto import ENCRYPTION_METHOD,ENCRYPTION_ENABLED, INTEGRITY_ENABLED, INTEGRITY_METHOD
+from .crypto.crypto_selector import (
+    add_integrity,
+    authenticate,
+    check_integrity,
+    decrypt,
+    encrypt,
+    verify_authentication,
+)
+from .crypto.config_cripto import (
+    AUTH_ENABLED,
+    AUTH_METHOD,
+    ENCRYPTION_METHOD,
+    ENCRYPTION_ENABLED,
+    INTEGRITY_ENABLED,
+    INTEGRITY_METHOD,
+)
 from .crypto import log_file
 from .crypto.log_file import log_time
 from .typing import (
@@ -56,7 +70,8 @@ def arrayrecord_to_parameters(record: ArrayRecord, keep_input: bool) -> Paramete
     parameters = Parameters(tensors=[], tensor_type="")
 
     total_deser_time = 0.0   # tempo per costruire gli oggetti Parameters (no decrypt)
-    total_decrypt_time = 0.0 # tempo per decrypt + integrity
+    total_crypto_time = 0.0  # tempo crypto complessivo
+    total_auth_time = 0.0
 
     # Iteriamo direttamente sulle chiavi senza creare copie costose
     for key in list(record.keys()):
@@ -76,17 +91,25 @@ def arrayrecord_to_parameters(record: ArrayRecord, keep_input: bool) -> Paramete
         total_deser_time += (end_deser - start_deser)
 
         # --- DECRYPT + INTEGRITY ---
-        if INTEGRITY_ENABLED or ENCRYPTION_ENABLED:
-            start_decrypt = time.perf_counter()
+        if AUTH_ENABLED or INTEGRITY_ENABLED or ENCRYPTION_ENABLED:
+            if AUTH_ENABLED:
+                start_auth = time.perf_counter()
+                data = verify_authentication(data, AUTH_METHOD)
+                end_auth = time.perf_counter()
+                total_auth_time += (end_auth - start_auth)
+                total_crypto_time += (end_auth - start_auth)
 
             if INTEGRITY_ENABLED:
+                start_integrity = time.perf_counter()
                 data = check_integrity(data, INTEGRITY_METHOD)
+                end_integrity = time.perf_counter()
+                total_crypto_time += (end_integrity - start_integrity)
 
             if ENCRYPTION_ENABLED:
+                start_decrypt = time.perf_counter()
                 data = decrypt(data, ENCRYPTION_METHOD)
-
-            end_decrypt = time.perf_counter()
-            total_decrypt_time += (end_decrypt - start_decrypt)
+                end_decrypt = time.perf_counter()
+                total_crypto_time += (end_decrypt - start_decrypt)
 
         # aggiungi il tensor
         parameters.tensors.append(data)
@@ -96,15 +119,20 @@ def arrayrecord_to_parameters(record: ArrayRecord, keep_input: bool) -> Paramete
             del record[key]
 
     # LOG TEMPI REALI
-    total_time = total_deser_time + total_decrypt_time
-    crypto_impact = (total_decrypt_time / total_time * 100.0) if total_time > 0 else 0.0
-    log_file.add_crypto_time(total_decrypt_time, total_deser_time)
+    total_time = total_deser_time + total_crypto_time
+    crypto_impact = (total_crypto_time / total_time * 100.0) if total_time > 0 else 0.0
+    log_file.add_crypto_time(total_crypto_time, total_deser_time)
     log_time(
-        "CRYPTO STATUS: enabled=%s method=%s | DESERIALIZE: %.5f s | CRYPTO: %.5f s | TOTAL: %.5f s | IMPACT: %.2f%%",
+        "CRYPTO STATUS: enabled=%s method=%s | auth_enabled=%s auth_method=%s | "
+        "DESERIALIZE: %.5f s | CRYPTO: %.5f s | AUTH: %.5f s | TOTAL: %.5f s | "
+        "IMPACT: %.2f%%",
         ENCRYPTION_ENABLED,
         ENCRYPTION_METHOD,
+        AUTH_ENABLED,
+        AUTH_METHOD,
         total_deser_time,
-        total_decrypt_time,
+        total_crypto_time,
+        total_auth_time,
         total_time,
         crypto_impact,
     )
@@ -120,6 +148,7 @@ def parameters_to_arrayrecord(parameters: Parameters, keep_input: bool) -> Array
     # Tempi separati
     tot_serial_time = 0.0
     tot_crypto_time = 0.0
+    tot_auth_time = 0.0
 
     for idx in range(num_arrays):
 
@@ -134,17 +163,25 @@ def parameters_to_arrayrecord(parameters: Parameters, keep_input: bool) -> Array
         tot_serial_time += (end_serial - start_serial)
 
         # --- CRITTOGRAFIA ---
-        if ENCRYPTION_ENABLED or INTEGRITY_ENABLED:
-            start_crypto = time.perf_counter()
+        if ENCRYPTION_ENABLED:
+            start_encrypt = time.perf_counter()
+            dataR = encrypt(dataR, ENCRYPTION_METHOD)
+            end_encrypt = time.perf_counter()
+            tot_crypto_time += (end_encrypt - start_encrypt)
 
-            if ENCRYPTION_ENABLED:
-                dataR = encrypt(dataR, ENCRYPTION_METHOD)
+        if INTEGRITY_ENABLED:
+            start_integrity = time.perf_counter()
+            dataR = add_integrity(dataR, INTEGRITY_METHOD)
+            end_integrity = time.perf_counter()
+            tot_crypto_time += (end_integrity - start_integrity)
 
-            if INTEGRITY_ENABLED:
-                dataR = add_integrity(dataR, INTEGRITY_METHOD)
-
-            end_crypto = time.perf_counter()
-            tot_crypto_time += (end_crypto - start_crypto)
+        if AUTH_ENABLED:
+            start_auth = time.perf_counter()
+            dataR = authenticate(dataR, AUTH_METHOD)
+            end_auth = time.perf_counter()
+            auth_elapsed = end_auth - start_auth
+            tot_auth_time += auth_elapsed
+            tot_crypto_time += auth_elapsed
 
         # --- COSTRUZIONE ARRAY ---
         ordered_dict[str(idx)] = Array(
@@ -162,11 +199,16 @@ def parameters_to_arrayrecord(parameters: Parameters, keep_input: bool) -> Array
     crypto_impact = (tot_crypto_time / total_time * 100.0) if total_time > 0 else 0.0
     log_file.add_crypto_time(tot_crypto_time, tot_serial_time)
     log_time(
-        "CRYPTO STATUS: enabled=%s method=%s | SERIALIZE: %.5f s | CRYPTO: %.5f s | TOTAL: %.5f s | IMPACT: %.2f%%",
+        "CRYPTO STATUS: enabled=%s method=%s | auth_enabled=%s auth_method=%s | "
+        "SERIALIZE: %.5f s | CRYPTO: %.5f s | AUTH: %.5f s | TOTAL: %.5f s | "
+        "IMPACT: %.2f%%",
         ENCRYPTION_ENABLED,
         ENCRYPTION_METHOD,
+        AUTH_ENABLED,
+        AUTH_METHOD,
         tot_serial_time,
         tot_crypto_time,
+        tot_auth_time,
         total_time,
         crypto_impact,
     )


### PR DESCRIPTION
### Motivation

- Provide a Koblitz-only authentication option (112/256/512) so flows that only need authentication can be selected and measured.  
- Make authentication selectable from the interactive crypto setup and keep sensible defaults in a dedicated config file.  
- Track authentication timing separately so the runtime/impact of authentication can be reported alongside encryption/integrity timings.

### Description

- Added `authenticate` and `verify` helpers to `framework/py/flwr/common/crypto/algorithms/KOBLITZ.py` to produce/verify an HMAC-SHA256 tag prefixed with an ephemeral secret.  
- Exposed Koblitz authentication through the crypto selector by adding `authenticate` and `verify_authentication` in `framework/py/flwr/common/crypto/crypto_selector.py`.  
- Introduced a default crypto configuration file `framework/py/flwr/common/crypto/config_cripto.py` with `AUTH_ENABLED`/`AUTH_METHOD` and other defaults.  
- Extended the interactive setup `framework/py/flwr/common/crypto/start.py` to allow enabling authentication and selecting a Koblitz method, and updated `framework/py/flwr/common/recorddict_compat.py` to apply authentication on serialization/deserialization, measure auth times, accumulate them into the crypto totals, and include auth info in the `CRYPTO STATUS` logs.

### Testing

- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69748929d7708332aebfaa79edbe28fa)