### PR TITLE
Add ECCFROG522PP curve option to crypto Koblitz registry

### DIFF
--- a/framework/py/flwr/common/crypto/algorithms/KOBLITZ.py
+++ b/framework/py/flwr/common/crypto/algorithms/KOBLITZ.py
@@ -29,6 +29,7 @@ SUPPORTED_CURVES: Dict[str, KoblitzCurve] = {
     "KOBLITZ_LARGE": KoblitzCurve("KOBLITZ_LARGE", 512),
     "CURVE25519": KoblitzCurve("CURVE25519", 256),
     "CURVE448": KoblitzCurve("CURVE448", 448),
+    "ECCFROG522PP": KoblitzCurve("ECCFROG522PP", 522),
 }
 
 LEGACY_ALIASES: Dict[str, str] = {

--- a/framework/py/flwr/common/crypto/start.py
+++ b/framework/py/flwr/common/crypto/start.py
@@ -21,6 +21,10 @@ AUTH_METHODS = [
     "KOBLITZ_512",
     "CURVE25519",
     "CURVE448",
+    # ECCFROG522PP: livello di sicurezza alto, overhead alto (previsto almeno),
+    # nuova proposta del 2025, cofattore 1. Uso tipico: massima sicurezza quando
+    # il costo computazionale non è un limite.
+    "ECCFROG522PP",
 ]
 NET_OPTIONS = ["custom_cnn", "resnet18", "resnet34", "tiny_cnn", "squeezenet"]
 EVALUATION_OPTIONS = ["server", "client"]


### PR DESCRIPTION
### Motivation
- Add the new `ECCFROG522PP` curve as a high-security option (2025 proposal, cofactor 1, higher overhead) so it can be selected for authentication in the demo crypto stack.

### Description
- Add `ECCFROG522PP` (522-bit) to `SUPPORTED_CURVES` in `framework/py/flwr/common/crypto/algorithms/KOBLITZ.py` and expose it in `AUTH_METHODS` in `framework/py/flwr/common/crypto/start.py` with a short usage/security/overhead comment.

### Testing
- No automated tests were run for this change; the modification only adds a new curve constant and an auth-method string.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69774cd9feb083329f9007b559fc9ac1)