### PR TITLE
Use real Koblitz curve mappings for auth options

### DIFF
--- a/framework/py/flwr/common/crypto/algorithms/KOBLITZ.py
+++ b/framework/py/flwr/common/crypto/algorithms/KOBLITZ.py
@@ -31,9 +31,9 @@ class KoblitzCurve:
 SUPPORTED_CURVES: Dict[str, KoblitzCurve] = {
     "ECDSA_256": KoblitzCurve("ECDSA_256", 256, ec.SECP256R1()),
     "ECDSA_521": KoblitzCurve("ECDSA_521", 521, ec.SECP521R1()),
-    "KOBLITZ_112": KoblitzCurve("KOBLITZ_112", 192, ec.SECP192R1()),
+    "KOBLITZ_112": KoblitzCurve("KOBLITZ_112", 163, ec.SECT163K1()),
     "KOBLITZ_256": KoblitzCurve("KOBLITZ_256", 256, ec.SECP256K1()),
-    "KOBLITZ_512": KoblitzCurve("KOBLITZ_512", 521, ec.SECP521R1()),
+    "KOBLITZ_512": KoblitzCurve("KOBLITZ_512", 571, ec.SECT571K1()),
     "CURVE25519": KoblitzCurve("CURVE25519", 256, ed25519.Ed25519PrivateKey),
     "CURVE448": KoblitzCurve("CURVE448", 448, ed448.Ed448PrivateKey),
     "ECCFROG522PP": KoblitzCurve("ECCFROG522PP", 521, ec.SECP521R1()),


### PR DESCRIPTION
### Motivation
- Sostituire le curve simulate R1 con curve Koblitz reali per le opzioni di autenticazione "KOBLITZ_112" e "KOBLITZ_512" in modo da supportare curve reali richieste.

### Description
- Aggiornato `framework/py/flwr/common/crypto/algorithms/KOBLITZ.py` per mappare `"KOBLITZ_112"` a `ec.SECT163K1()` (163 bit) e `"KOBLITZ_512"` a `ec.SECT571K1()` (571 bit).

### Testing
- Eseguito un controllo rapido con Python per verificare che `ec.SECT163K1` e `ec.SECT571K1` siano esposti dalla libreria `cryptography`, e non sono stati eseguiti test automatici.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69788149c7c0833281230110c80cfa24)