### PR TITLE
Add BLAKE3 parameter derivation for ECCFROG522PP and integrate ECCFROG into KOBLITZ signature flow

### DIFF
--- a/framework/py/flwr/common/crypto/algorithms/KOBLITZ.py
+++ b/framework/py/flwr/common/crypto/algorithms/KOBLITZ.py
@@ -16,6 +16,8 @@ from cryptography.hazmat.primitives.serialization import (
     load_pem_public_key,
 )
 
+from . import eccfrog
+
 
 @dataclass(frozen=True)
 class KoblitzCurve:
@@ -38,7 +40,7 @@ SUPPORTED_CURVES: Dict[str, KoblitzCurve] = {
     "KOBLITZ_512": KoblitzCurve("KOBLITZ_512", 571, ec.SECT571K1()),
     "CURVE25519": KoblitzCurve("CURVE25519", 256, ed25519.Ed25519PrivateKey),
     "CURVE448": KoblitzCurve("CURVE448", 448, ed448.Ed448PrivateKey),
-    "ECCFROG522PP": KoblitzCurve("ECCFROG522PP", 521, ec.SECP521R1()),
+    "ECCFROG522PP": KoblitzCurve("ECCFROG522PP", 521, "ECCFROG522PP"),
 }
 
 LEGACY_ALIASES: Dict[str, str] = {}
@@ -58,9 +60,11 @@ def is_supported_method(curve_name: str) -> bool:
     return curve_name in SUPPORTED_METHODS
 
 
-def _load_public_key(key: object) -> object:
+def _load_public_key(key: object, curve: KoblitzCurve) -> object:
     if key is None:
         raise ValueError("Chiave pubblica mancante per la curva scelta")
+    if curve.name == "ECCFROG522PP":
+        return eccfrog.load_public_key(key)
     if isinstance(key, (bytes, bytearray)):
         return load_pem_public_key(bytes(key))
     if isinstance(key, str):
@@ -68,9 +72,11 @@ def _load_public_key(key: object) -> object:
     return key
 
 
-def _load_private_key(key: object) -> object:
+def _load_private_key(key: object, curve: KoblitzCurve) -> object:
     if key is None:
         raise ValueError("Chiave privata mancante per la curva scelta")
+    if curve.name == "ECCFROG522PP":
+        return eccfrog.load_private_key(key)
     if isinstance(key, (bytes, bytearray)):
         return load_pem_private_key(bytes(key), password=None)
     if isinstance(key, str):
@@ -82,14 +88,14 @@ def _pack_signature(
     data: bytes, signature: bytes, public_key_bytes: bytes | None = None
 ) -> bytes:
     if public_key_bytes is None:
-        return data + struct.pack(">H", len(signature)) + signature
+        return data + signature + struct.pack(">H", len(signature))
     return (
         data
         + b"FLPK"
         + struct.pack(">H", len(public_key_bytes))
         + public_key_bytes
-        + struct.pack(">H", len(signature))
         + signature
+        + struct.pack(">H", len(signature))
     )
 
 
@@ -102,12 +108,16 @@ def _unpack_signature(payload: bytes) -> tuple[bytes, bytes, bytes | None]:
     signature = payload[-2 - sig_len : -2]
     remaining = payload[: -2 - sig_len]
     if len(remaining) >= 6:
-        public_key_len = struct.unpack(">H", remaining[-2:])[0]
-        marker_start = len(remaining) - (6 + public_key_len)
-        if marker_start >= 0 and remaining[marker_start : marker_start + 4] == b"FLPK":
-            public_key = remaining[marker_start + 6 : marker_start + 6 + public_key_len]
-            data = remaining[:marker_start]
-            return data, signature, public_key
+        marker_start = remaining.rfind(b"FLPK")
+        if marker_start != -1 and len(remaining) >= marker_start + 6:
+            public_key_len = struct.unpack(
+                ">H", remaining[marker_start + 4 : marker_start + 6]
+            )[0]
+            public_key_end = marker_start + 6 + public_key_len
+            if public_key_end == len(remaining):
+                public_key = remaining[marker_start + 6 : public_key_end]
+                data = remaining[:marker_start]
+                return data, signature, public_key
     data = remaining
     return data, signature, None
 
@@ -117,6 +127,16 @@ def authenticate(data: bytes, curve_name: str, ecc_privkey: object) -> bytes:
 
     curve = _get_curve(curve_name)
     include_public_key = ecc_privkey is None
+    if curve.name == "ECCFROG522PP":
+        if ecc_privkey is None:
+            private_key = eccfrog.generate_private_key()
+        else:
+            private_key = _load_private_key(ecc_privkey, curve)
+        signature = eccfrog.sign(data, private_key)
+        public_key_bytes = (
+            private_key.public_key.to_bytes() if include_public_key else None
+        )
+        return _pack_signature(data, signature, public_key_bytes)
     if ecc_privkey is None:
         if curve.curve is ed25519.Ed25519PrivateKey:
             private_key = ed25519.Ed25519PrivateKey.generate()
@@ -125,7 +145,7 @@ def authenticate(data: bytes, curve_name: str, ecc_privkey: object) -> bytes:
         else:
             private_key = ec.generate_private_key(curve.curve)
     else:
-        private_key = _load_private_key(ecc_privkey)
+        private_key = _load_private_key(ecc_privkey, curve)
     if isinstance(private_key, (ed25519.Ed25519PrivateKey, ed448.Ed448PrivateKey)):
         signature = private_key.sign(data)
         public_key_bytes = (
@@ -152,14 +172,24 @@ def authenticate(data: bytes, curve_name: str, ecc_privkey: object) -> bytes:
 def verify(authenticated_data: bytes, curve_name: str, ecc_pubkey: object) -> bytes:
     """Verifica l'autenticazione creata da :func:`authenticate`."""
 
-    _get_curve(curve_name)
+    curve = _get_curve(curve_name)
     data, signature, embedded_public_key = _unpack_signature(authenticated_data)
+    if curve.name == "ECCFROG522PP":
+        if ecc_pubkey is None:
+            if embedded_public_key is None:
+                raise ValueError("Chiave pubblica mancante per la curva scelta")
+            public_key = _load_public_key(embedded_public_key, curve)
+        else:
+            public_key = _load_public_key(ecc_pubkey, curve)
+        if not eccfrog.verify(data, signature, public_key):
+            raise ValueError("Firma non valida")
+        return data
     if ecc_pubkey is None:
         if embedded_public_key is None:
             raise ValueError("Chiave pubblica mancante per la curva scelta")
-        public_key = _load_public_key(embedded_public_key)
+        public_key = _load_public_key(embedded_public_key, curve)
     else:
-        public_key = _load_public_key(ecc_pubkey)
+        public_key = _load_public_key(ecc_pubkey, curve)
     try:
         if isinstance(public_key, (ed25519.Ed25519PublicKey, ed448.Ed448PublicKey)):
             public_key.verify(signature, data)

--- a/framework/py/flwr/common/crypto/algorithms/eccfrog.py
+++ b/framework/py/flwr/common/crypto/algorithms/eccfrog.py
@@ -1,0 +1,255 @@
+"""Implementazione della curva ECCFROG522PP e delle firme ECDSA."""
+
+from __future__ import annotations
+
+import hashlib
+import secrets
+from dataclasses import dataclass
+
+try:  # Optional dependency for deterministic parameter derivation
+    from blake3 import blake3 as _blake3
+except ImportError:  # pragma: no cover - optional dependency
+    _blake3 = None
+
+P = int(
+    "686479766013060971498190079908139321726943530014330540939446345918554318"
+    "339765605212255964066145455497729631139148085803712198799971664381257402"
+    "8291115058039"
+)
+A = -9 % P
+B = int(
+    "661139136184195850860452469937744791138999490012975421307768311225096419"
+    "509388251093415492337101182055425457255989613682399356563300695566619742"
+    "8760619911"
+)
+N = int(
+    "686479766013060971498190079908139321726943530014330540939446345918554318"
+    "339765470783993099806907243717889863432321841973824511791072608043490749"
+    "5541251156283"
+)
+GX = int(
+    "114836598700559139646235363713136312609767670986199491984058026550790121"
+    "317888159000151000981405923011587990724012666535482931446873066751491073"
+    "89798128134"
+)
+GY = int(
+    "303869445742844202438813211737067794312734393851211346303431863870960045"
+    "113632574702513861080239149191409127648110569935391920249490281068659303"
+    "0172286395020"
+)
+
+KEY_SIZE_BITS = 521
+KEY_SIZE_BYTES = (KEY_SIZE_BITS + 7) // 8
+SEED = "ECCFrog522PP|v1"
+B_INDEX = 1_294_798
+G_INDEX = 0
+DERIVATION_DIGEST_BYTES = 64
+
+
+@dataclass(frozen=True)
+class ECPoint:
+    """Rappresentazione di un punto affine sulla curva."""
+
+    x: int
+    y: int
+
+    def to_bytes(self) -> bytes:
+        return b"\x04" + _int_to_bytes(self.x) + _int_to_bytes(self.y)
+
+
+@dataclass(frozen=True)
+class ECCFROGPublicKey:
+    point: ECPoint
+
+    def to_bytes(self) -> bytes:
+        return self.point.to_bytes()
+
+
+@dataclass(frozen=True)
+class ECCFROGPrivateKey:
+    secret: int
+    public_key: ECCFROGPublicKey
+
+    def to_bytes(self) -> bytes:
+        return _int_to_bytes(self.secret)
+
+
+def generate_private_key() -> ECCFROGPrivateKey:
+    secret = secrets.randbelow(N - 1) + 1
+    public_point = scalar_mult(secret, ECPoint(GX, GY))
+    if public_point is None:  # pragma: no cover - sicurezza
+        raise ValueError("Punto pubblico non valido")
+    return ECCFROGPrivateKey(secret, ECCFROGPublicKey(public_point))
+
+
+def derive_b(seed: str = SEED, index: int = B_INDEX) -> int:
+    """Deriva il coefficiente b usando BLAKE3 secondo la pipeline pubblicata."""
+    digest = _blake3_digest(_encode_derivation(seed, "b", index))
+    return (int.from_bytes(digest, "big") % (P - 3)) + 2
+
+
+def derive_base_point_x(seed: str = SEED, index: int = G_INDEX) -> int:
+    """Deriva la coordinata x del punto base usando BLAKE3."""
+    digest = _blake3_digest(_encode_derivation(seed, "G", index))
+    return int.from_bytes(digest, "big") % P
+
+
+def validate_parameters() -> bool:
+    """Verifica che i parametri pubblicati coincidano con la derivazione BLAKE3."""
+    if _blake3 is None:
+        return False
+    return derive_b() == B and derive_base_point_x() == GX
+
+
+def load_private_key(key: object) -> ECCFROGPrivateKey:
+    if isinstance(key, ECCFROGPrivateKey):
+        return key
+    if isinstance(key, int):
+        secret = key
+    elif isinstance(key, (bytes, bytearray)):
+        secret = int.from_bytes(bytes(key), "big")
+    elif isinstance(key, str):
+        key_str = key.strip().lower()
+        if key_str.startswith("0x"):
+            key_str = key_str[2:]
+        secret = int.from_bytes(bytes.fromhex(key_str), "big")
+    else:
+        raise ValueError("Formato chiave privata ECCFROG non supportato")
+    if not (1 <= secret < N):
+        raise ValueError("Chiave privata ECCFROG fuori range")
+    public_point = scalar_mult(secret, ECPoint(GX, GY))
+    if public_point is None:  # pragma: no cover - sicurezza
+        raise ValueError("Punto pubblico non valido")
+    return ECCFROGPrivateKey(secret, ECCFROGPublicKey(public_point))
+
+
+def load_public_key(key: object) -> ECCFROGPublicKey:
+    if isinstance(key, ECCFROGPublicKey):
+        return key
+    if isinstance(key, ECPoint):
+        return ECCFROGPublicKey(key)
+    if isinstance(key, (bytes, bytearray)):
+        key_bytes = bytes(key)
+    elif isinstance(key, str):
+        key_str = key.strip().lower()
+        if key_str.startswith("0x"):
+            key_str = key_str[2:]
+        key_bytes = bytes.fromhex(key_str)
+    else:
+        raise ValueError("Formato chiave pubblica ECCFROG non supportato")
+    if len(key_bytes) != 1 + 2 * KEY_SIZE_BYTES or key_bytes[0] != 0x04:
+        raise ValueError("Chiave pubblica ECCFROG non valida")
+    x = int.from_bytes(key_bytes[1 : 1 + KEY_SIZE_BYTES], "big")
+    y = int.from_bytes(key_bytes[1 + KEY_SIZE_BYTES :], "big")
+    point = ECPoint(x, y)
+    if not is_on_curve(point):
+        raise ValueError("Punto pubblico ECCFROG non sulla curva")
+    return ECCFROGPublicKey(point)
+
+
+def sign(message: bytes, private_key: ECCFROGPrivateKey) -> bytes:
+    z = _hash_to_int(message)
+    while True:
+        k = secrets.randbelow(N - 1) + 1
+        r_point = scalar_mult(k, ECPoint(GX, GY))
+        if r_point is None:
+            continue
+        r = r_point.x % N
+        if r == 0:
+            continue
+        k_inv = _modinv(k, N)
+        s = (k_inv * (z + r * private_key.secret)) % N
+        if s == 0:
+            continue
+        return _int_to_bytes(r, size=KEY_SIZE_BYTES) + _int_to_bytes(
+            s, size=KEY_SIZE_BYTES
+        )
+
+
+def verify(message: bytes, signature: bytes, public_key: ECCFROGPublicKey) -> bool:
+    if len(signature) != 2 * KEY_SIZE_BYTES:
+        return False
+    r = int.from_bytes(signature[:KEY_SIZE_BYTES], "big")
+    s = int.from_bytes(signature[KEY_SIZE_BYTES:], "big")
+    if not (1 <= r < N and 1 <= s < N):
+        return False
+    z = _hash_to_int(message)
+    w = _modinv(s, N)
+    u1 = (z * w) % N
+    u2 = (r * w) % N
+    point = point_add(
+        scalar_mult(u1, ECPoint(GX, GY)),
+        scalar_mult(u2, public_key.point),
+    )
+    if point is None:
+        return False
+    return (point.x % N) == r
+
+
+def is_on_curve(point: ECPoint) -> bool:
+    return (point.y * point.y - (point.x * point.x * point.x + A * point.x + B)) % P == 0
+
+
+def scalar_mult(k: int, point: ECPoint | None) -> ECPoint | None:
+    if point is None or k % N == 0:
+        return None
+    result = None
+    addend = point
+    while k:
+        if k & 1:
+            result = point_add(result, addend)
+        addend = point_double(addend)
+        k >>= 1
+    return result
+
+
+def point_add(p1: ECPoint | None, p2: ECPoint | None) -> ECPoint | None:
+    if p1 is None:
+        return p2
+    if p2 is None:
+        return p1
+    if p1.x == p2.x and (p1.y != p2.y or p1.y == 0):
+        return None
+    if p1.x == p2.x:
+        return point_double(p1)
+    slope = ((p2.y - p1.y) * _modinv(p2.x - p1.x, P)) % P
+    x3 = (slope * slope - p1.x - p2.x) % P
+    y3 = (slope * (p1.x - x3) - p1.y) % P
+    return ECPoint(x3, y3)
+
+
+def point_double(point: ECPoint | None) -> ECPoint | None:
+    if point is None:
+        return None
+    if point.y == 0:
+        return None
+    slope = ((3 * point.x * point.x + A) * _modinv(2 * point.y, P)) % P
+    x3 = (slope * slope - 2 * point.x) % P
+    y3 = (slope * (point.x - x3) - point.y) % P
+    return ECPoint(x3, y3)
+
+
+def _hash_to_int(message: bytes) -> int:
+    digest = hashlib.sha256(message).digest()
+    return int.from_bytes(digest, "big") % N
+
+
+def _int_to_bytes(value: int, size: int = KEY_SIZE_BYTES) -> bytes:
+    return value.to_bytes(size, "big")
+
+
+def _modinv(value: int, modulus: int) -> int:
+    return pow(value, -1, modulus)
+
+
+def _encode_derivation(seed: str, tag: str, index: int) -> bytes:
+    return seed.encode() + b"|" + tag.encode() + b"|" + str(index).encode()
+
+
+def _blake3_digest(data: bytes) -> bytes:
+    if _blake3 is None:
+        raise RuntimeError(
+            "BLAKE3 non disponibile. Installa il pacchetto 'blake3' "
+            "per riprodurre i parametri ECCFROG522PP."
+        )
+    return _blake3(data).digest(length=DERIVATION_DIGEST_BYTES)


### PR DESCRIPTION
### Motivation
- Reproduce the parameter-generation pipeline described in the ECCFROG paper by providing optional BLAKE3-backed derivation helpers for the curve parameters instead of only relying on hardcoded values.
- Ensure the custom `ECCFROG522PP` implementation is usable inside the existing KOBLITZ authentication flow and fix signature framing/unpacking issues that caused unpacking errors.
- Provide a clear runtime fallback when `blake3` is not available while enabling reproducible validation when it is installed.

### Description
- Added a new `framework/py/flwr/common/crypto/algorithms/eccfrog.py` module that implements ECCFROG522PP affine point math, key classes (`ECCFROGPrivateKey`, `ECCFROGPublicKey`), ECDSA-style `sign`/`verify`, and optional derivation helpers `derive_b`, `derive_base_point_x`, and `validate_parameters` that use an optional `blake3` dependency via `_blake3_digest` and `_encode_derivation`.
- Made `blake3` optional by guarding the import and raising a clear `RuntimeError` from `_blake3_digest` if the package is not installed, and have `validate_parameters()` return `False` when `blake3` is missing.
- Integrated ECCFROG into `KOBLITZ.py` by importing `eccfrog`, registering `

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6979b465d54483328d5afbf4abc70b9d)