### PR TITLE
feat(customCryptography): log per-client CPU/RAM to serialization CSV via `log_time`

### DIFF
--- a/examples/customCriptography/customCryptographyExample/server_app.py
+++ b/examples/customCriptography/customCryptographyExample/server_app.py
@@ -44,7 +44,7 @@ class FedAvgWithServerEval(FedAvg):
             ram_end = metrics.get("ram_end_mb")
             ram_delta = metrics.get("ram_delta_mb")
             if cpu is not None and ram_start is not None and ram_end is not None:
-                print(
+                log_time(
                     f"[Round {server_round}] Client {cid} | "
                     f"CPU={cpu:.4f}s RAM_start={ram_start:.2f}MB "
                     f"RAM_end={ram_end:.2f}MB RAM_delta={ram_delta:.2f}MB"


### PR DESCRIPTION
### Motivation
- Ensure per-client CPU and RAM metrics are appended to the serialization report file (the `serialization_times_*.csv` used by the Telegram listener) instead of only being printed to stdout.

### Description
- Replace the `print(...)` used for per-client CPU/RAM lines with `log_time(...)` in `examples/customCriptography/customCryptographyExample/server_app.py` so those lines are written to the CSV produced by the crypto logging utilities.

### Testing
- Ran `python -m py_compile examples/customCriptography/customCryptographyExample/server_app.py` which succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699da8b22cd883329fb4a840d918c7ca)