### PR TITLE
Add per-round client CPU & wall-time logging and metrics

### DIFF
--- a/examples/customCriptography/customCryptographyExample/client_app.py
+++ b/examples/customCriptography/customCryptographyExample/client_app.py
@@ -1,6 +1,7 @@
 """authexample: An authenticated Flower / PyTorch app."""
 import logging
 import os
+import time
 
 import numpy as np
 import psutil
@@ -46,17 +47,28 @@ class FlowerClient(NumPyClient):
         self.lr = learning_rate
         self.device = torch.device("cuda:0" if torch.cuda.is_available() else "cpu")
         self.process = psutil.Process(os.getpid())
+        self.num_cores = psutil.cpu_count(logical=True) or 1
 
 
     def _cpu_time(self):
         t = self.process.cpu_times()
         return t.user + t.system
+
+    @staticmethod
+    def _extract_round(config):
+        for key in ("server_round", "server-round", "current_round", "round"):
+            if key in config:
+                return config[key]
+        return "unknown"
+
     def fit(self, parameters, config):
         try:
             set_weights(self.net, parameters)
+            server_round = self._extract_round(config)
 
             # misurazione CPU
             start_cpu = self._cpu_time()
+            start_wall = time.perf_counter()
 
             results = train(
                 self.net,
@@ -68,7 +80,11 @@ class FlowerClient(NumPyClient):
             )
 
             end_cpu = self._cpu_time()
+            end_wall = time.perf_counter()
             cpu_time = end_cpu - start_cpu
+            wall_time = end_wall - start_wall
+            cores_used_equivalent = cpu_time / wall_time if wall_time > 0 else 0.0
+            cpu_usage_pct = (cores_used_equivalent / self.num_cores) * 100
             # cpu_logger.info(f"{cpu_time:.3f}", extra={"pid": os.getpid()})
             weights = get_weights(self.net)
 
@@ -81,7 +97,25 @@ class FlowerClient(NumPyClient):
                 f"-> ~{packets} pacchetti TCP (MSS={MSS})"
             )
 
-            return weights, len(self.trainloader.dataset), {"cpu_fit": cpu_time}
+            logging.info(
+                "CPU per round | pid=%s | round=%s | cpu_time=%.3fs | wall_time=%.3fs "
+                "| core_equiv=%.2f | logical_cores=%s | cpu_pct=%.2f%%",
+                os.getpid(),
+                server_round,
+                cpu_time,
+                wall_time,
+                cores_used_equivalent,
+                self.num_cores,
+                cpu_usage_pct,
+            )
+
+            return weights, len(self.trainloader.dataset), {
+                "cpu_fit": cpu_time,
+                "fit_wall_time": wall_time,
+                "fit_core_equiv": cores_used_equivalent,
+                "fit_cpu_pct": cpu_usage_pct,
+                "fit_round": server_round,
+            }
         except Exception:
             logging.exception("ERRORE in fit() sul client, il client sta crashando!")
             raise


### PR DESCRIPTION
### Motivation
- Fornire nei log e nelle metriche il consumo CPU reale di ogni client per round in ambienti multi-core, distinguendo tra tempo CPU e tempo reale (wall-clock).
- Consentire di capire il parallelismo effettivo (più core usati contemporaneamente) e normalizzare l'uso rispetto ai core logici disponibili.

### Description
- Instrumented `FlowerClient.fit` in `examples/customCriptography/customCryptographyExample/client_app.py` to measure process CPU time (`user + system`) and wall-clock time (`time.perf_counter`).
- Added extraction of the server round from `config` (keys: `server_round`, `server-round`, `current_round`, `round`) to tag logs and returned metrics by round.
- Computed `core_equiv = cpu_time / wall_time` and normalized CPU percentage `cpu_pct = core_equiv / logical_cores * 100` using `psutil.cpu_count(logical=True)`, logged a single info line with `pid`, `round`, `cpu_time`, `wall_time`, `core_equiv`, `logical_cores`, and `cpu_pct`.
- Returned the new measurements in the `fit` return metrics dictionary as `cpu_fit`, `fit_wall_time`, `fit_core_equiv`, `fit_cpu_pct`, and `fit_round`.

### Testing
- Compiled the modified file with `python -m py_compile examples/customCriptography/customCryptographyExample/client_app.py` and it succeeded.
- No additional automated unit tests were added or run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a0909a39c8833292cab025a9ca8b6f)