### PR TITLE
Record per-client CPU/wall-time in fit(), send round to clients, and aggregate fit metrics on server

### DIFF
--- a/examples/customCriptography/customCryptographyExample/client_app.py
+++ b/examples/customCriptography/customCryptographyExample/client_app.py
@@ -1,6 +1,9 @@
 """authexample: An authenticated Flower / PyTorch app."""
 import logging
 import os
+import time
+
+from flwr.common.logger import log
 
 import numpy as np
 import psutil
@@ -46,17 +49,28 @@ class FlowerClient(NumPyClient):
         self.lr = learning_rate
         self.device = torch.device("cuda:0" if torch.cuda.is_available() else "cpu")
         self.process = psutil.Process(os.getpid())
+        self.num_cores = psutil.cpu_count(logical=True) or 1
 
 
     def _cpu_time(self):
         t = self.process.cpu_times()
         return t.user + t.system
+
+    @staticmethod
+    def _extract_round(config):
+        for key in ("server_round", "server-round", "current_round", "round"):
+            if key in config:
+                return config[key]
+        return "unknown"
+
     def fit(self, parameters, config):
         try:
             set_weights(self.net, parameters)
+            server_round = self._extract_round(config)
 
             # misurazione CPU
             start_cpu = self._cpu_time()
+            start_wall = time.perf_counter()
 
             results = train(
                 self.net,
@@ -68,7 +82,11 @@ class FlowerClient(NumPyClient):
             )
 
             end_cpu = self._cpu_time()
+            end_wall = time.perf_counter()
             cpu_time = end_cpu - start_cpu
+            wall_time = end_wall - start_wall
+            cores_used_equivalent = cpu_time / wall_time if wall_time > 0 else 0.0
+            cpu_usage_pct = (cores_used_equivalent / self.num_cores) * 100
             # cpu_logger.info(f"{cpu_time:.3f}", extra={"pid": os.getpid()})
             weights = get_weights(self.net)
 
@@ -81,7 +99,52 @@ class FlowerClient(NumPyClient):
                 f"-> ~{packets} pacchetti TCP (MSS={MSS})"
             )
 
-            return weights, len(self.trainloader.dataset), {"cpu_fit": cpu_time}
+            cpu_line = (
+                "CPU per round | pid=%s | round=%s | cpu_time=%.3fs | wall_time=%.3fs "
+                "| core_equiv=%.2f | logical_cores=%s | cpu_pct=%.2f%%"
+            )
+            logging.info(
+                cpu_line,
+                os.getpid(),
+                server_round,
+                cpu_time,
+                wall_time,
+                cores_used_equivalent,
+                self.num_cores,
+                cpu_usage_pct,
+            )
+            log(
+                logging.INFO,
+                cpu_line,
+                os.getpid(),
+                server_round,
+                cpu_time,
+                wall_time,
+                cores_used_equivalent,
+                self.num_cores,
+                cpu_usage_pct,
+            )
+            print(
+                cpu_line
+                % (
+                    os.getpid(),
+                    server_round,
+                    cpu_time,
+                    wall_time,
+                    cores_used_equivalent,
+                    self.num_cores,
+                    cpu_usage_pct,
+                ),
+                flush=True,
+            )
+
+            return weights, len(self.trainloader.dataset), {
+                "cpu_fit": cpu_time,
+                "fit_wall_time": wall_time,
+                "fit_core_equiv": cores_used_equivalent,
+                "fit_cpu_pct": cpu_usage_pct,
+                "fit_round": server_round,
+            }
         except Exception:
             logging.exception("ERRORE in fit() sul client, il client sta crashando!")
             raise

--- a/examples/customCriptography/customCryptographyExample/server_app.py
+++ b/examples/customCriptography/customCryptographyExample/server_app.py
@@ -1,4 +1,5 @@
 from flwr.common import Context, Metrics, ndarrays_to_parameters, parameters_to_ndarrays
+import logging
 from flwr.common.logger import log
 from flwr.server import ServerApp, ServerAppComponents, ServerConfig
 from flwr.server.strategy import FedAvg
@@ -26,6 +27,62 @@ def weighted_average(metrics):
     accuracies = [num_examples * m["accuracy"] for num_examples, m in metrics]
     examples = [num_examples for num_examples, _ in metrics]
     return {"accuracy": sum(accuracies) / sum(examples)}
+
+
+
+
+def get_on_fit_config_fn():
+    """Return fit config with explicit round number for clients."""
+
+    def fit_config_fn(server_round: int) -> dict[str, Scalar]:
+        return {"current_round": server_round}
+
+    return fit_config_fn
+
+def aggregate_fit_metrics(metrics: list[tuple[int, Metrics]]) -> Metrics:
+    """Aggregate and print per-client CPU metrics returned by fit()."""
+    if not metrics:
+        return {}
+
+    total_examples = sum(num_examples for num_examples, _ in metrics)
+    weighted_cpu_time = 0.0
+    weighted_wall_time = 0.0
+    weighted_core_equiv = 0.0
+    weighted_cpu_pct = 0.0
+
+    for idx, (num_examples, metric) in enumerate(metrics, start=1):
+        cpu_time = float(metric.get("cpu_fit", 0.0))
+        wall_time = float(metric.get("fit_wall_time", 0.0))
+        core_equiv = float(metric.get("fit_core_equiv", 0.0))
+        cpu_pct = float(metric.get("fit_cpu_pct", 0.0))
+        fit_round = metric.get("fit_round", "unknown")
+
+        weighted_cpu_time += cpu_time * num_examples
+        weighted_wall_time += wall_time * num_examples
+        weighted_core_equiv += core_equiv * num_examples
+        weighted_cpu_pct += cpu_pct * num_examples
+
+        log(
+            logging.INFO,
+            "[Round %s] Client-%s metrics | examples=%s | cpu_time=%.3fs | wall_time=%.3fs | core_equiv=%.2f | cpu_pct=%.2f%%",
+            fit_round,
+            idx,
+            num_examples,
+            cpu_time,
+            wall_time,
+            core_equiv,
+            cpu_pct,
+        )
+
+    if total_examples == 0:
+        return {}
+
+    return {
+        "cpu_fit": weighted_cpu_time / total_examples,
+        "fit_wall_time": weighted_wall_time / total_examples,
+        "fit_core_equiv": weighted_core_equiv / total_examples,
+        "fit_cpu_pct": weighted_cpu_pct / total_examples,
+    }
 
 
 class FedAvgWithServerEval(FedAvg):
@@ -144,7 +201,9 @@ def server_fn(context: Context):
         min_available_clients=2,
         evaluate_fn=server_side,
         initial_parameters=parameters,
+        on_fit_config_fn=get_on_fit_config_fn(),
         evaluate_metrics_aggregation_fn=weighted_average,
+        fit_metrics_aggregation_fn=aggregate_fit_metrics,
         stop_criteria={"metric_ge": ("accuracy", ACCURACY),
         },
     )


### PR DESCRIPTION
### Motivation
- Add per-client CPU and wall-clock timing to better understand local training cost and core-equivalent utilization.
- Ensure clients know the current federated round by shipping a round identifier in the fit config (`current_round`).
- Aggregate and log the new client-side timing metrics server-side to compute weighted averages across clients and aid debugging.

### Description
- Instrumented the client `fit()` to record CPU time and wall time, compute core-equivalent and percent CPU utilization, and include those metrics in the returned fit metrics (`cpu_fit`, `fit_wall_time`, `fit_core_equiv`, `fit_cpu_pct`, `fit_round`).
- Added `_extract_round()` on the client to read the round from incoming `config` keys and included `num_cores` detection via `psutil` to compute `cpu_pct`.
- Added logging and printing of a compact CPU metrics line on the client using `log` and `logging` for easier centralized logging.
- On the server, added `get_on_fit_config_fn()` to provide `current_round` to clients and implemented `aggregate_fit_metrics()` to aggregate per-client timing metrics into weighted averages and to log per-client metrics; the server strategy is wired with `on_fit_config_fn=get_on_fit_config_fn()` and `fit_metrics_aggregation_fn=aggregate_fit_metrics`.

### Testing
- No automated tests were added or executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a0909a39c8833292cab025a9ca8b6f)