### PR TITLE
Measure and aggregate per-client CPU/time metrics in customCryptography example

### DIFF
--- a/examples/customCriptography/customCryptographyExample/client_app.py
+++ b/examples/customCriptography/customCryptographyExample/client_app.py
@@ -1,6 +1,9 @@
 """authexample: An authenticated Flower / PyTorch app."""
 import logging
 import os
+import time
+
+from flwr.common.logger import log
 
 import numpy as np
 import psutil
@@ -46,17 +49,28 @@ class FlowerClient(NumPyClient):
         self.lr = learning_rate
         self.device = torch.device("cuda:0" if torch.cuda.is_available() else "cpu")
         self.process = psutil.Process(os.getpid())
+        self.num_cores = psutil.cpu_count(logical=True) or 1
 
 
     def _cpu_time(self):
         t = self.process.cpu_times()
         return t.user + t.system
+
+    @staticmethod
+    def _extract_round(config):
+        for key in ("server_round", "server-round", "current_round", "round"):
+            if key in config:
+                return config[key]
+        return "unknown"
+
     def fit(self, parameters, config):
         try:
             set_weights(self.net, parameters)
+            server_round = self._extract_round(config)
 
             # misurazione CPU
             start_cpu = self._cpu_time()
+            inizio_tempo_reale = time.perf_counter()
 
             results = train(
                 self.net,
@@ -68,7 +82,11 @@ class FlowerClient(NumPyClient):
             )
 
             end_cpu = self._cpu_time()
-            cpu_time = end_cpu - start_cpu
+            fine_tempo_reale = time.perf_counter()
+            tempo_cpu = end_cpu - start_cpu
+            tempo_reale = fine_tempo_reale - inizio_tempo_reale
+            core_equivalenti = tempo_cpu / tempo_reale if tempo_reale > 0 else 0.0
+            percentuale_cpu = (core_equivalenti / self.num_cores) * 100
             # cpu_logger.info(f"{cpu_time:.3f}", extra={"pid": os.getpid()})
             weights = get_weights(self.net)
 
@@ -81,7 +99,56 @@ class FlowerClient(NumPyClient):
                 f"-> ~{packets} pacchetti TCP (MSS={MSS})"
             )
 
-            return weights, len(self.trainloader.dataset), {"cpu_fit": cpu_time}
+            cpu_line = (
+                "CPU per round | pid=%s | round=%s | tempo_cpu=%.3fs | tempo_reale=%.3fs "
+                "| core_equivalenti=%.2f | core_logici=%s | percentuale_cpu=%.2f%%"
+            )
+            logging.info(
+                cpu_line,
+                os.getpid(),
+                server_round,
+                tempo_cpu,
+                tempo_reale,
+                core_equivalenti,
+                self.num_cores,
+                percentuale_cpu,
+            )
+            log(
+                logging.INFO,
+                cpu_line,
+                os.getpid(),
+                server_round,
+                tempo_cpu,
+                tempo_reale,
+                core_equivalenti,
+                self.num_cores,
+                percentuale_cpu,
+            )
+            print(
+                cpu_line
+                % (
+                    os.getpid(),
+                    server_round,
+                    tempo_cpu,
+                    tempo_reale,
+                    core_equivalenti,
+                    self.num_cores,
+                    percentuale_cpu,
+                ),
+                flush=True,
+            )
+
+            return weights, len(self.trainloader.dataset), {
+                "tempo_cpu_fit": tempo_cpu,
+                "cpu_fit": tempo_cpu,
+                "tempo_reale_fit": tempo_reale,
+                "fit_wall_time": tempo_reale,
+                "core_equivalenti_fit": core_equivalenti,
+                "fit_core_equiv": core_equivalenti,
+                "percentuale_cpu_fit": percentuale_cpu,
+                "fit_cpu_pct": percentuale_cpu,
+                "fit_round": server_round,
+            }
         except Exception:
             logging.exception("ERRORE in fit() sul client, il client sta crashando!")
             raise

--- a/examples/customCriptography/customCryptographyExample/server_app.py
+++ b/examples/customCriptography/customCryptographyExample/server_app.py
@@ -1,4 +1,5 @@
 from flwr.common import Context, Metrics, ndarrays_to_parameters, parameters_to_ndarrays
+import logging
 from flwr.common.logger import log
 from flwr.server import ServerApp, ServerAppComponents, ServerConfig
 from flwr.server.strategy import FedAvg
@@ -26,6 +27,66 @@ def weighted_average(metrics):
     accuracies = [num_examples * m["accuracy"] for num_examples, m in metrics]
     examples = [num_examples for num_examples, _ in metrics]
     return {"accuracy": sum(accuracies) / sum(examples)}
+
+
+
+
+def get_on_fit_config_fn():
+    """Return fit config with explicit round number for clients."""
+
+    def fit_config_fn(server_round: int) -> dict[str, Scalar]:
+        return {"current_round": server_round}
+
+    return fit_config_fn
+
+def aggregate_fit_metrics(metrics: list[tuple[int, Metrics]]) -> Metrics:
+    """Aggregate and print per-client CPU metrics returned by fit()."""
+    if not metrics:
+        return {}
+
+    total_examples = sum(num_examples for num_examples, _ in metrics)
+    tempo_cpu_pesato = 0.0
+    tempo_reale_pesato = 0.0
+    core_equivalenti_pesati = 0.0
+    percentuale_cpu_pesata = 0.0
+
+    for idx, (num_examples, metric) in enumerate(metrics, start=1):
+        tempo_cpu = float(metric.get("tempo_cpu_fit", metric.get("cpu_fit", 0.0)))
+        tempo_reale = float(metric.get("tempo_reale_fit", metric.get("fit_wall_time", 0.0)))
+        core_equivalenti = float(metric.get("core_equivalenti_fit", metric.get("fit_core_equiv", 0.0)))
+        percentuale_cpu = float(metric.get("percentuale_cpu_fit", metric.get("fit_cpu_pct", 0.0)))
+        fit_round = metric.get("fit_round", "unknown")
+
+        tempo_cpu_pesato += tempo_cpu * num_examples
+        tempo_reale_pesato += tempo_reale * num_examples
+        core_equivalenti_pesati += core_equivalenti * num_examples
+        percentuale_cpu_pesata += percentuale_cpu * num_examples
+
+        log(
+            logging.INFO,
+            "[Round %s] Client-%s metriche | esempi=%s | tempo_cpu=%.3fs | tempo_reale=%.3fs | core_equivalenti=%.2f | percentuale_cpu=%.2f%%",
+            fit_round,
+            idx,
+            num_examples,
+            tempo_cpu,
+            tempo_reale,
+            core_equivalenti,
+            percentuale_cpu,
+        )
+
+    if total_examples == 0:
+        return {}
+
+    return {
+        "tempo_cpu_fit": tempo_cpu_pesato / total_examples,
+        "tempo_reale_fit": tempo_reale_pesato / total_examples,
+        "core_equivalenti_fit": core_equivalenti_pesati / total_examples,
+        "percentuale_cpu_fit": percentuale_cpu_pesata / total_examples,
+        "cpu_fit": tempo_cpu_pesato / total_examples,
+        "fit_wall_time": tempo_reale_pesato / total_examples,
+        "fit_core_equiv": core_equivalenti_pesati / total_examples,
+        "fit_cpu_pct": percentuale_cpu_pesata / total_examples,
+    }
 
 
 class FedAvgWithServerEval(FedAvg):
@@ -144,7 +205,9 @@ def server_fn(context: Context):
         min_available_clients=2,
         evaluate_fn=server_side,
         initial_parameters=parameters,
+        on_fit_config_fn=get_on_fit_config_fn(),
         evaluate_metrics_aggregation_fn=weighted_average,
+        fit_metrics_aggregation_fn=aggregate_fit_metrics,
         stop_criteria={"metric_ge": ("accuracy", ACCURACY),
         },
     )


### PR DESCRIPTION
### Motivation

- Add per-client CPU and wall-clock timing to the training `fit` so resource usage can be measured per round.
- Surface per-client metrics to the server and provide a server-side aggregation to observe weighted CPU/wall-time statistics across clients. 

### Description

- In `client_app.py` the `FlowerClient` now measures CPU time and wall-clock time in `fit`, computes equivalent cores and CPU percentage, extracts a round identifier from the `config`, logs these details, and returns multiple metrics (`tempo_cpu_fit`, `tempo_reale_fit`, `core_equivalenti_fit`, `percentuale_cpu_fit`, and synonyms) along with `fit_round` in the `fit` result. 
- Added helper `_extract_round` and `num_cores` discovery via `psutil.cpu_count` to the client to better label and normalize measurements. 
- In `server_app.py` added `get_on_fit_config_fn` to send `current_round` to clients and implemented `aggregate_fit_metrics` which aggregates per-client CPU/time metrics weighted by number of examples and logs per-client entries. 
- Wire the server strategy to use `on_fit_config_fn=get_on_fit_config_fn()` and `fit_metrics_aggregation_fn=aggregate_fit_metrics`, and left `evaluate` behavior unchanged.

### Testing

- No automated tests were added or run for these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a0909a39c8833292cab025a9ca8b6f)