### PR TITLE
Collect and aggregate per-client CPU/RAM metrics and propagate round id to clients

### DIFF
--- a/examples/customCriptography/customCryptographyExample/client_app.py
+++ b/examples/customCriptography/customCryptographyExample/client_app.py
@@ -1,6 +1,9 @@
 """authexample: An authenticated Flower / PyTorch app."""
 import logging
 import os
+import time
+
+from flwr.common.logger import log
 
 import numpy as np
 import psutil
@@ -46,17 +49,36 @@ class FlowerClient(NumPyClient):
         self.lr = learning_rate
         self.device = torch.device("cuda:0" if torch.cuda.is_available() else "cpu")
         self.process = psutil.Process(os.getpid())
+        self.num_cores = psutil.cpu_count(logical=True) or 1
 
 
     def _cpu_time(self):
         t = self.process.cpu_times()
         return t.user + t.system
+
+    def _ram_bytes(self):
+        return self.process.memory_info().rss
+
+    @staticmethod
+    def _bytes_to_mb(value_bytes):
+        return value_bytes / (1024 * 1024)
+
+    @staticmethod
+    def _extract_round(config):
+        for key in ("server_round", "server-round", "current_round", "round"):
+            if key in config:
+                return config[key]
+        return "unknown"
+
     def fit(self, parameters, config):
         try:
             set_weights(self.net, parameters)
+            server_round = self._extract_round(config)
 
-            # misurazione CPU
+            # misurazione CPU/RAM
             start_cpu = self._cpu_time()
+            ram_iniziale_bytes = self._ram_bytes()
+            inizio_tempo_reale = time.perf_counter()
 
             results = train(
                 self.net,
@@ -68,7 +90,15 @@ class FlowerClient(NumPyClient):
             )
 
             end_cpu = self._cpu_time()
-            cpu_time = end_cpu - start_cpu
+            fine_tempo_reale = time.perf_counter()
+            tempo_cpu = end_cpu - start_cpu
+            tempo_reale = fine_tempo_reale - inizio_tempo_reale
+            core_equivalenti = tempo_cpu / tempo_reale if tempo_reale > 0 else 0.0
+            percentuale_cpu = (core_equivalenti / self.num_cores) * 100
+            ram_finale_bytes = self._ram_bytes()
+            delta_ram_bytes = ram_finale_bytes - ram_iniziale_bytes
+            ram_totale_sistema_bytes = psutil.virtual_memory().total
+            percentuale_ram_sistema = (ram_finale_bytes / ram_totale_sistema_bytes) * 100
             # cpu_logger.info(f"{cpu_time:.3f}", extra={"pid": os.getpid()})
             weights = get_weights(self.net)
 
@@ -81,7 +111,51 @@ class FlowerClient(NumPyClient):
                 f"-> ~{packets} pacchetti TCP (MSS={MSS})"
             )
 
-            return weights, len(self.trainloader.dataset), {"cpu_fit": cpu_time}
+            cpu_line = (
+                "CPU per round | pid=%s | round=%s | tempo_cpu=%.3fs | tempo_reale=%.3fs "
+                "| core_equivalenti=%.2f | core_logici=%s | percentuale_cpu=%.2f%%"
+            )
+            log(
+                logging.INFO,
+                cpu_line,
+                os.getpid(),
+                server_round,
+                tempo_cpu,
+                tempo_reale,
+                core_equivalenti,
+                self.num_cores,
+                percentuale_cpu,
+            )
+
+            ram_line = (
+                "RAM per round | pid=%s | round=%s | ram_iniziale=%.1fMB | ram_finale=%.1fMB "
+                "| delta_ram=%.1fMB | ram_sistema_pct=%.2f%%"
+            )
+            ram_iniziale_mb = self._bytes_to_mb(ram_iniziale_bytes)
+            ram_finale_mb = self._bytes_to_mb(ram_finale_bytes)
+            delta_ram_mb = self._bytes_to_mb(delta_ram_bytes)
+            log(
+                logging.INFO,
+                ram_line,
+                os.getpid(),
+                server_round,
+                ram_iniziale_mb,
+                ram_finale_mb,
+                delta_ram_mb,
+                percentuale_ram_sistema,
+            )
+
+            return weights, len(self.trainloader.dataset), {
+                "tempo_cpu_fit": tempo_cpu,
+                "tempo_reale_fit": tempo_reale,
+                "core_equivalenti_fit": core_equivalenti,
+                "percentuale_cpu_fit": percentuale_cpu,
+                "fit_round": server_round,
+                "ram_iniziale_mb_fit": ram_iniziale_mb,
+                "ram_finale_mb_fit": ram_finale_mb,
+                "delta_ram_mb_fit": delta_ram_mb,
+                "percentuale_ram_sistema_fit": percentuale_ram_sistema,
+            }
         except Exception:
             logging.exception("ERRORE in fit() sul client, il client sta crashando!")
             raise

--- a/examples/customCriptography/customCryptographyExample/server_app.py
+++ b/examples/customCriptography/customCryptographyExample/server_app.py
@@ -1,4 +1,5 @@
 from flwr.common import Context, Metrics, ndarrays_to_parameters, parameters_to_ndarrays
+import logging
 from flwr.common.logger import log
 from flwr.server import ServerApp, ServerAppComponents, ServerConfig
 from flwr.server.strategy import FedAvg
@@ -26,6 +27,82 @@ def weighted_average(metrics):
     accuracies = [num_examples * m["accuracy"] for num_examples, m in metrics]
     examples = [num_examples for num_examples, _ in metrics]
     return {"accuracy": sum(accuracies) / sum(examples)}
+
+
+
+
+def get_on_fit_config_fn():
+    """Return fit config with explicit round number for clients."""
+
+    def fit_config_fn(server_round: int) -> dict[str, Scalar]:
+        return {"current_round": server_round}
+
+    return fit_config_fn
+
+def aggregate_fit_metrics(metrics: list[tuple[int, Metrics]]) -> Metrics:
+    """Aggregate and print per-client CPU metrics returned by fit()."""
+    if not metrics:
+        return {}
+
+    total_examples = sum(num_examples for num_examples, _ in metrics)
+    tempo_cpu_pesato = 0.0
+    tempo_reale_pesato = 0.0
+    core_equivalenti_pesati = 0.0
+    percentuale_cpu_pesata = 0.0
+    ram_iniziale_mb_pesata = 0.0
+    ram_finale_mb_pesata = 0.0
+    delta_ram_mb_pesata = 0.0
+    percentuale_ram_sistema_pesata = 0.0
+
+    for idx, (num_examples, metric) in enumerate(metrics, start=1):
+        tempo_cpu = float(metric.get("tempo_cpu_fit", 0.0))
+        tempo_reale = float(metric.get("tempo_reale_fit", 0.0))
+        core_equivalenti = float(metric.get("core_equivalenti_fit", 0.0))
+        percentuale_cpu = float(metric.get("percentuale_cpu_fit", 0.0))
+        ram_iniziale_mb = float(metric.get("ram_iniziale_mb_fit", 0.0))
+        ram_finale_mb = float(metric.get("ram_finale_mb_fit", 0.0))
+        delta_ram_mb = float(metric.get("delta_ram_mb_fit", 0.0))
+        percentuale_ram_sistema = float(metric.get("percentuale_ram_sistema_fit", 0.0))
+        fit_round = metric.get("fit_round", "unknown")
+
+        tempo_cpu_pesato += tempo_cpu * num_examples
+        tempo_reale_pesato += tempo_reale * num_examples
+        core_equivalenti_pesati += core_equivalenti * num_examples
+        percentuale_cpu_pesata += percentuale_cpu * num_examples
+        ram_iniziale_mb_pesata += ram_iniziale_mb * num_examples
+        ram_finale_mb_pesata += ram_finale_mb * num_examples
+        delta_ram_mb_pesata += delta_ram_mb * num_examples
+        percentuale_ram_sistema_pesata += percentuale_ram_sistema * num_examples
+
+        log(
+            logging.INFO,
+            "[Round %s] Client-%s metriche | esempi=%s | tempo_cpu=%.3fs | tempo_reale=%.3fs | core_equivalenti=%.2f | percentuale_cpu=%.2f%% | ram_ini=%.1fMB | ram_fin=%.1fMB | delta_ram=%.1fMB | ram_sistema=%.2f%%",
+            fit_round,
+            idx,
+            num_examples,
+            tempo_cpu,
+            tempo_reale,
+            core_equivalenti,
+            percentuale_cpu,
+            ram_iniziale_mb,
+            ram_finale_mb,
+            delta_ram_mb,
+            percentuale_ram_sistema,
+        )
+
+    if total_examples == 0:
+        return {}
+
+    return {
+        "tempo_cpu_fit": tempo_cpu_pesato / total_examples,
+        "tempo_reale_fit": tempo_reale_pesato / total_examples,
+        "core_equivalenti_fit": core_equivalenti_pesati / total_examples,
+        "percentuale_cpu_fit": percentuale_cpu_pesata / total_examples,
+        "ram_iniziale_mb_fit": ram_iniziale_mb_pesata / total_examples,
+        "ram_finale_mb_fit": ram_finale_mb_pesata / total_examples,
+        "delta_ram_mb_fit": delta_ram_mb_pesata / total_examples,
+        "percentuale_ram_sistema_fit": percentuale_ram_sistema_pesata / total_examples,
+    }
 
 
 class FedAvgWithServerEval(FedAvg):
@@ -144,7 +221,9 @@ def server_fn(context: Context):
         min_available_clients=2,
         evaluate_fn=server_side,
         initial_parameters=parameters,
+        on_fit_config_fn=get_on_fit_config_fn(),
         evaluate_metrics_aggregation_fn=weighted_average,
+        fit_metrics_aggregation_fn=aggregate_fit_metrics,
         stop_criteria={"metric_ge": ("accuracy", ACCURACY),
         },
     )


### PR DESCRIPTION
### Motivation
- Add visibility into client resource consumption per training round and associate reported metrics with an explicit round identifier to enable server-side aggregation and inspection.

### Description
- In `client_app.py` add wall-clock timing and process resource measurements (`time.perf_counter()`, CPU time, RAM via `psutil`), helper functions (`_ram_bytes`, `_bytes_to_mb`, `_extract_round`), record logical core count via `psutil.cpu_count`, and log detailed per-round CPU/RAM info using `log` and return expanded fit metrics (`tempo_cpu_fit`, `tempo_reale_fit`, `core_equivalenti_fit`, `percentuale_cpu_fit`, `ram_*`, etc.).
- In `server_app.py` introduce `get_on_fit_config_fn` to send the current round to clients, implement `aggregate_fit_metrics` to compute weighted averages of the reported CPU/RAM metrics and log per-client metrics, and wire these into the FedAvg strategy via `on_fit_config_fn` and `fit_metrics_aggregation_fn`.
- Add/adjust imports and minor bookkeeping (import `time`, use `psutil.cpu_count`, adapt logging lines) to support the new measurements and aggregation.

### Testing
- No automated tests were added or executed for these example changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a0909a39c8833292cab025a9ca8b6f)