### PR TITLE
Log per-round encryption and decryption timings

### DIFF
--- a/framework/py/flwr/common/crypto/log_file.py
+++ b/framework/py/flwr/common/crypto/log_file.py
@@ -6,6 +6,8 @@ from .config_cripto import ENCRYPTION_METHOD, ENCRYPTION_ENABLED
 CSV_PATH = None
 CSV_INITIALIZED = False
 TOTAL_CRYPTO_TIME = 0.0
+TOTAL_ENCRYPT_TIME = 0.0
+TOTAL_DECRYPT_TIME = 0.0
 TOTAL_SERIAL_TIME = 0.0
 TOTAL_AUTH_TIME = 0.0
 TOTAL_OVERHEAD_BYTES = 0
@@ -18,11 +20,14 @@ OVERHEAD_COUNT_BY_CATEGORY: Dict[str, int] = {}
 
 def reset_crypto_totals() -> None:
     """Reset accumulated crypto/serialization totals."""
-    global TOTAL_CRYPTO_TIME, TOTAL_SERIAL_TIME, TOTAL_AUTH_TIME
+    global TOTAL_CRYPTO_TIME, TOTAL_ENCRYPT_TIME, TOTAL_DECRYPT_TIME
+    global TOTAL_SERIAL_TIME, TOTAL_AUTH_TIME
     global TOTAL_OVERHEAD_BYTES, TOTAL_PLAINTEXT_BYTES
     global OVERHEAD_BY_METHOD, OVERHEAD_COUNT_BY_METHOD
     global OVERHEAD_BY_CATEGORY, OVERHEAD_COUNT_BY_CATEGORY
     TOTAL_CRYPTO_TIME = 0.0
+    TOTAL_ENCRYPT_TIME = 0.0
+    TOTAL_DECRYPT_TIME = 0.0
     TOTAL_SERIAL_TIME = 0.0
     TOTAL_AUTH_TIME = 0.0
     TOTAL_OVERHEAD_BYTES = 0
@@ -40,6 +45,13 @@ def add_crypto_time(crypto_time: float, serial_time: float) -> None:
     TOTAL_SERIAL_TIME += serial_time
 
 
+def add_encrypt_decrypt_time(encrypt_time: float, decrypt_time: float) -> None:
+    """Accumulate encryption/decryption time for summary reporting."""
+    global TOTAL_ENCRYPT_TIME, TOTAL_DECRYPT_TIME
+    TOTAL_ENCRYPT_TIME += encrypt_time
+    TOTAL_DECRYPT_TIME += decrypt_time
+
+
 def add_auth_time(auth_time: float) -> None:
     """Accumulate authentication time for summary reporting."""
     global TOTAL_AUTH_TIME
@@ -49,6 +61,11 @@ def add_auth_time(auth_time: float) -> None:
 def get_crypto_totals() -> tuple[float, float]:
     """Return accumulated crypto and serialization totals."""
     return TOTAL_CRYPTO_TIME, TOTAL_SERIAL_TIME
+
+
+def get_encrypt_decrypt_totals() -> tuple[float, float]:
+    """Return accumulated encryption and decryption totals."""
+    return TOTAL_ENCRYPT_TIME, TOTAL_DECRYPT_TIME
 
 
 def get_auth_totals() -> float:
@@ -191,6 +208,8 @@ def build_round_time_report() -> List[str]:
     for summary in ROUND_SUMMARIES:
         round_time = summary["round_time"]
         crypto_time = summary["crypto_time"]
+        encrypt_time = summary.get("encrypt_time", 0.0)
+        decrypt_time = summary.get("decrypt_time", 0.0)
         without_crypto = summary["without_crypto"]
         auth_time = summary.get("auth_time", 0.0)
         crypto_cumulative = summary.get("crypto_cumulative", crypto_time)
@@ -214,6 +233,7 @@ def build_round_time_report() -> List[str]:
         lines.append(
             "Round {round_num}: totale={round_time:.2f}s | "
             "crypto={crypto_time:.2f}s ({impact:.2f}%) | "
+            "encrypt={encrypt_time:.2f}s | decrypt={decrypt_time:.2f}s | "
             "auth={auth_time:.2f}s ({auth_impact:.2f}%) | "
             "crypto_cum={crypto_cumulative:.2f}s | auth_cum={auth_cumulative:.2f}s | "
             "senza_critto={without_crypto:.2f}s{parallel_note}".format(
@@ -221,6 +241,8 @@ def build_round_time_report() -> List[str]:
                 round_time=round_time,
                 crypto_time=crypto_time,
                 impact=impact,
+                encrypt_time=encrypt_time,
+                decrypt_time=decrypt_time,
                 auth_time=auth_time,
                 auth_impact=auth_impact,
                 crypto_cumulative=crypto_cumulative,

--- a/framework/py/flwr/common/recorddict_compat.py
+++ b/framework/py/flwr/common/recorddict_compat.py
@@ -71,6 +71,7 @@ def arrayrecord_to_parameters(record: ArrayRecord, keep_input: bool) -> Paramete
 
     total_deser_time = 0.0   # tempo per costruire gli oggetti Parameters (no decrypt)
     total_crypto_time = 0.0  # tempo crypto (cifratura/integrità)
+    total_decrypt_time = 0.0
     total_auth_time = 0.0
 
     # Iteriamo direttamente sulle chiavi senza creare copie costose
@@ -107,7 +108,9 @@ def arrayrecord_to_parameters(record: ArrayRecord, keep_input: bool) -> Paramete
             start_decrypt = time.perf_counter()
             data = decrypt(data, ENCRYPTION_METHOD)
             end_decrypt = time.perf_counter()
-            total_crypto_time += (end_decrypt - start_decrypt)
+            decrypt_elapsed = end_decrypt - start_decrypt
+            total_crypto_time += decrypt_elapsed
+            total_decrypt_time += decrypt_elapsed
 
         # aggiungi il tensor
         parameters.tensors.append(data)
@@ -121,6 +124,7 @@ def arrayrecord_to_parameters(record: ArrayRecord, keep_input: bool) -> Paramete
     crypto_impact = (total_crypto_time / total_time * 100.0) if total_time > 0 else 0.0
     auth_impact = (total_auth_time / total_time * 100.0) if total_time > 0 else 0.0
     log_file.add_crypto_time(total_crypto_time, total_deser_time)
+    log_file.add_encrypt_decrypt_time(0.0, total_decrypt_time)
     log_file.add_auth_time(total_auth_time)
     log_time(
         "CRYPTO STATUS: enabled=%s method=%s | auth_enabled=%s auth_method=%s | "
@@ -149,6 +153,7 @@ def parameters_to_arrayrecord(parameters: Parameters, keep_input: bool) -> Array
     # Tempi separati
     tot_serial_time = 0.0
     tot_crypto_time = 0.0
+    tot_encrypt_time = 0.0
     tot_auth_time = 0.0
 
     for idx in range(num_arrays):
@@ -170,7 +175,9 @@ def parameters_to_arrayrecord(parameters: Parameters, keep_input: bool) -> Array
             start_encrypt = time.perf_counter()
             dataR = encrypt(dataR, ENCRYPTION_METHOD)
             end_encrypt = time.perf_counter()
-            tot_crypto_time += (end_encrypt - start_encrypt)
+            encrypt_elapsed = end_encrypt - start_encrypt
+            tot_crypto_time += encrypt_elapsed
+            tot_encrypt_time += encrypt_elapsed
             log_file.add_overhead(
                 ENCRYPTION_METHOD,
                 "crypto",
@@ -221,6 +228,7 @@ def parameters_to_arrayrecord(parameters: Parameters, keep_input: bool) -> Array
     crypto_impact = (tot_crypto_time / total_time * 100.0) if total_time > 0 else 0.0
     auth_impact = (tot_auth_time / total_time * 100.0) if total_time > 0 else 0.0
     log_file.add_crypto_time(tot_crypto_time, tot_serial_time)
+    log_file.add_encrypt_decrypt_time(tot_encrypt_time, 0.0)
     log_file.add_auth_time(tot_auth_time)
     log_time(
         "CRYPTO STATUS: enabled=%s method=%s | auth_enabled=%s auth_method=%s | "

--- a/framework/py/flwr/server/server.py
+++ b/framework/py/flwr/server/server.py
@@ -149,6 +149,7 @@ class Server:
 
         # Run federated learning for num_rounds
         prev_crypto_total, _ = log_file.get_crypto_totals()
+        prev_encrypt_total, prev_decrypt_total = log_file.get_encrypt_decrypt_totals()
         prev_auth_total = log_file.get_auth_totals()
 
         for current_round in range(1, num_rounds + 1):
@@ -214,14 +215,25 @@ class Server:
             # Fine round: calcolo e log del tempo
             round_elapsed = timeit.default_timer() - round_start
             current_crypto_total, _ = log_file.get_crypto_totals()
+            current_encrypt_total, current_decrypt_total = log_file.get_encrypt_decrypt_totals()
             current_auth_total = log_file.get_auth_totals()
             round_crypto_time = max(current_crypto_total - prev_crypto_total, 0.0)
+            round_encrypt_time = max(current_encrypt_total - prev_encrypt_total, 0.0)
+            round_decrypt_time = max(current_decrypt_total - prev_decrypt_total, 0.0)
             round_auth_time = max(current_auth_total - prev_auth_total, 0.0)
             prev_crypto_total = current_crypto_total
+            prev_encrypt_total = current_encrypt_total
+            prev_decrypt_total = current_decrypt_total
             prev_auth_total = current_auth_total
             parallel_factor = max(round_fit_parallel, round_eval_parallel, 1)
             parallel_crypto_time = min(
                 round_crypto_time / parallel_factor, round_elapsed
+            )
+            parallel_encrypt_time = min(
+                round_encrypt_time / parallel_factor, round_elapsed
+            )
+            parallel_decrypt_time = min(
+                round_decrypt_time / parallel_factor, round_elapsed
             )
             parallel_auth_time = min(
                 round_auth_time / parallel_factor, round_elapsed
@@ -232,6 +244,8 @@ class Server:
                 "round_time": round_elapsed,
                 "crypto_time": parallel_crypto_time,
                 "crypto_cumulative": round_crypto_time,
+                "encrypt_time": parallel_encrypt_time,
+                "decrypt_time": parallel_decrypt_time,
                 "auth_time": parallel_auth_time,
                 "auth_cumulative": round_auth_time,
                 "parallel_fit": float(round_fit_parallel),
@@ -240,7 +254,13 @@ class Server:
                 "without_crypto": without_crypto,
             })
 
-            log_time("Tempo totale round %s: %.2f s", current_round, round_elapsed)
+            log_time(
+                "Tempo totale round %s: %.2f s | cifratura: %.2f s | decifratura: %.2f s",
+                current_round,
+                round_elapsed,
+                parallel_encrypt_time,
+                parallel_decrypt_time,
+            )
 
             history.add_metrics_centralized(
                 server_round=current_round,


### PR DESCRIPTION
### Motivation
- Provide visibility into how much time is spent specifically in encryption and decryption during each FL round so these costs are included with other round timing logs.

### Description
- Add cumulative counters and APIs for encryption/decryption (`TOTAL_ENCRYPT_TIME`, `TOTAL_DECRYPT_TIME`, `add_encrypt_decrypt_time`, `get_encrypt_decrypt_totals`) in `framework/py/flwr/common/crypto/log_file.py` and extend the per-round report format to include `encrypt` and `decrypt` values.
- Measure decrypt time when converting incoming `ArrayRecord` → `Parameters` and accumulate it via the new API in `framework/py/flwr/common/recorddict_compat.py`.
- Measure encrypt time when converting outgoing `Parameters` → `ArrayRecord` and accumulate it via the new API in `framework/py/flwr/common/recorddict_compat.py`.
- Compute per-round encrypt/decrypt deltas in the server loop, store them in `ROUND_SUMMARIES` and print them together with other round timing logs in `framework/py/flwr/server/server.py`.

### Testing
- Ran `python -m py_compile framework/py/flwr/common/crypto/log_file.py framework/py/flwr/common/recorddict_compat.py framework/py/flwr/server/server.py` to verify syntax, which completed successfully.
- Verified that `build_round_time_report()` now includes `encrypt` and `decrypt` fields and that server logging emits a per-round line containing `cifratura` and `decifratura` timings.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a6c275f8e48332ba23042978881fa8)