### PR TITLE
Add signature and verification timing to crypto round metrics

### DIFF
--- a/framework/py/flwr/common/crypto/log_file.py
+++ b/framework/py/flwr/common/crypto/log_file.py
@@ -10,6 +10,8 @@ TOTAL_ENCRYPT_TIME = 0.0
 TOTAL_DECRYPT_TIME = 0.0
 TOTAL_SERIAL_TIME = 0.0
 TOTAL_AUTH_TIME = 0.0
+TOTAL_AUTH_SIGN_TIME = 0.0
+TOTAL_AUTH_VERIFY_TIME = 0.0
 TOTAL_OVERHEAD_BYTES = 0
 TOTAL_PLAINTEXT_BYTES = 0
 OVERHEAD_BY_METHOD: Dict[str, int] = {}
@@ -22,6 +24,7 @@ def reset_crypto_totals() -> None:
     """Reset accumulated crypto/serialization totals."""
     global TOTAL_CRYPTO_TIME, TOTAL_ENCRYPT_TIME, TOTAL_DECRYPT_TIME
     global TOTAL_SERIAL_TIME, TOTAL_AUTH_TIME
+    global TOTAL_AUTH_SIGN_TIME, TOTAL_AUTH_VERIFY_TIME
     global TOTAL_OVERHEAD_BYTES, TOTAL_PLAINTEXT_BYTES
     global OVERHEAD_BY_METHOD, OVERHEAD_COUNT_BY_METHOD
     global OVERHEAD_BY_CATEGORY, OVERHEAD_COUNT_BY_CATEGORY
@@ -30,6 +33,8 @@ def reset_crypto_totals() -> None:
     TOTAL_DECRYPT_TIME = 0.0
     TOTAL_SERIAL_TIME = 0.0
     TOTAL_AUTH_TIME = 0.0
+    TOTAL_AUTH_SIGN_TIME = 0.0
+    TOTAL_AUTH_VERIFY_TIME = 0.0
     TOTAL_OVERHEAD_BYTES = 0
     TOTAL_PLAINTEXT_BYTES = 0
     OVERHEAD_BY_METHOD = {}
@@ -58,6 +63,13 @@ def add_auth_time(auth_time: float) -> None:
     TOTAL_AUTH_TIME += auth_time
 
 
+def add_auth_sign_verify_time(sign_time: float, verify_time: float) -> None:
+    """Accumulate authentication sign/verify times for summary reporting."""
+    global TOTAL_AUTH_SIGN_TIME, TOTAL_AUTH_VERIFY_TIME
+    TOTAL_AUTH_SIGN_TIME += sign_time
+    TOTAL_AUTH_VERIFY_TIME += verify_time
+
+
 def get_crypto_totals() -> tuple[float, float]:
     """Return accumulated crypto and serialization totals."""
     return TOTAL_CRYPTO_TIME, TOTAL_SERIAL_TIME
@@ -71,6 +83,11 @@ def get_encrypt_decrypt_totals() -> tuple[float, float]:
 def get_auth_totals() -> float:
     """Return accumulated authentication totals."""
     return TOTAL_AUTH_TIME
+
+
+def get_auth_sign_verify_totals() -> tuple[float, float]:
+    """Return accumulated authentication sign/verify totals."""
+    return TOTAL_AUTH_SIGN_TIME, TOTAL_AUTH_VERIFY_TIME
 
 
 def add_overhead(
@@ -212,6 +229,8 @@ def build_round_time_report() -> List[str]:
         decrypt_time = summary.get("decrypt_time", 0.0)
         without_crypto = summary["without_crypto"]
         auth_time = summary.get("auth_time", 0.0)
+        auth_sign_time = summary.get("auth_sign_time", 0.0)
+        auth_verify_time = summary.get("auth_verify_time", 0.0)
         crypto_cumulative = summary.get("crypto_cumulative", crypto_time)
         auth_cumulative = summary.get("auth_cumulative", auth_time)
         parallel_factor = summary.get("parallel_factor")
@@ -235,6 +254,7 @@ def build_round_time_report() -> List[str]:
             "crypto={crypto_time:.2f}s ({impact:.2f}%) | "
             "encrypt={encrypt_time:.2f}s | decrypt={decrypt_time:.2f}s | "
             "auth={auth_time:.2f}s ({auth_impact:.2f}%) | "
+            "firma={auth_sign_time:.2f}s | verifica={auth_verify_time:.2f}s | "
             "crypto_cum={crypto_cumulative:.2f}s | auth_cum={auth_cumulative:.2f}s | "
             "senza_critto={without_crypto:.2f}s{parallel_note}".format(
                 round_num=int(summary["round"]),
@@ -245,6 +265,8 @@ def build_round_time_report() -> List[str]:
                 decrypt_time=decrypt_time,
                 auth_time=auth_time,
                 auth_impact=auth_impact,
+                auth_sign_time=auth_sign_time,
+                auth_verify_time=auth_verify_time,
                 crypto_cumulative=crypto_cumulative,
                 auth_cumulative=auth_cumulative,
                 without_crypto=without_crypto,

--- a/framework/py/flwr/common/recorddict_compat.py
+++ b/framework/py/flwr/common/recorddict_compat.py
@@ -73,6 +73,7 @@ def arrayrecord_to_parameters(record: ArrayRecord, keep_input: bool) -> Paramete
     total_crypto_time = 0.0  # tempo crypto (cifratura/integrità)
     total_decrypt_time = 0.0
     total_auth_time = 0.0
+    total_auth_verify_time = 0.0
 
     # Iteriamo direttamente sulle chiavi senza creare copie costose
     for key in list(record.keys()):
@@ -96,7 +97,9 @@ def arrayrecord_to_parameters(record: ArrayRecord, keep_input: bool) -> Paramete
             start_auth = time.perf_counter()
             data = verify_authentication(data, AUTH_METHOD)
             end_auth = time.perf_counter()
-            total_auth_time += (end_auth - start_auth)
+            auth_verify_elapsed = end_auth - start_auth
+            total_auth_time += auth_verify_elapsed
+            total_auth_verify_time += auth_verify_elapsed
 
         if INTEGRITY_ENABLED:
             start_integrity = time.perf_counter()
@@ -126,6 +129,7 @@ def arrayrecord_to_parameters(record: ArrayRecord, keep_input: bool) -> Paramete
     log_file.add_crypto_time(total_crypto_time, total_deser_time)
     log_file.add_encrypt_decrypt_time(0.0, total_decrypt_time)
     log_file.add_auth_time(total_auth_time)
+    log_file.add_auth_sign_verify_time(0.0, total_auth_verify_time)
     log_time(
         "CRYPTO STATUS: enabled=%s method=%s | auth_enabled=%s auth_method=%s | "
         "DESERIALIZE: %.5f s | CRYPTO: %.5f s | AUTH: %.5f s | TOTAL: %.5f s | "
@@ -155,6 +159,7 @@ def parameters_to_arrayrecord(parameters: Parameters, keep_input: bool) -> Array
     tot_crypto_time = 0.0
     tot_encrypt_time = 0.0
     tot_auth_time = 0.0
+    tot_auth_sign_time = 0.0
 
     for idx in range(num_arrays):
 
@@ -205,6 +210,7 @@ def parameters_to_arrayrecord(parameters: Parameters, keep_input: bool) -> Array
             end_auth = time.perf_counter()
             auth_elapsed = end_auth - start_auth
             tot_auth_time += auth_elapsed
+            tot_auth_sign_time += auth_elapsed
             log_file.add_overhead(
                 AUTH_METHOD,
                 "auth",
@@ -230,6 +236,7 @@ def parameters_to_arrayrecord(parameters: Parameters, keep_input: bool) -> Array
     log_file.add_crypto_time(tot_crypto_time, tot_serial_time)
     log_file.add_encrypt_decrypt_time(tot_encrypt_time, 0.0)
     log_file.add_auth_time(tot_auth_time)
+    log_file.add_auth_sign_verify_time(tot_auth_sign_time, 0.0)
     log_time(
         "CRYPTO STATUS: enabled=%s method=%s | auth_enabled=%s auth_method=%s | "
         "SERIALIZE: %.5f s | CRYPTO: %.5f s | AUTH: %.5f s | TOTAL: %.5f s | "

--- a/framework/py/flwr/server/server.py
+++ b/framework/py/flwr/server/server.py
@@ -151,6 +151,7 @@ class Server:
         prev_crypto_total, _ = log_file.get_crypto_totals()
         prev_encrypt_total, prev_decrypt_total = log_file.get_encrypt_decrypt_totals()
         prev_auth_total = log_file.get_auth_totals()
+        prev_auth_sign_total, prev_auth_verify_total = log_file.get_auth_sign_verify_totals()
 
         for current_round in range(1, num_rounds + 1):
             if getattr(self.strategy, "stop_triggered", False):
@@ -217,14 +218,19 @@ class Server:
             current_crypto_total, _ = log_file.get_crypto_totals()
             current_encrypt_total, current_decrypt_total = log_file.get_encrypt_decrypt_totals()
             current_auth_total = log_file.get_auth_totals()
+            current_auth_sign_total, current_auth_verify_total = log_file.get_auth_sign_verify_totals()
             round_crypto_time = max(current_crypto_total - prev_crypto_total, 0.0)
             round_encrypt_time = max(current_encrypt_total - prev_encrypt_total, 0.0)
             round_decrypt_time = max(current_decrypt_total - prev_decrypt_total, 0.0)
             round_auth_time = max(current_auth_total - prev_auth_total, 0.0)
+            round_auth_sign_time = max(current_auth_sign_total - prev_auth_sign_total, 0.0)
+            round_auth_verify_time = max(current_auth_verify_total - prev_auth_verify_total, 0.0)
             prev_crypto_total = current_crypto_total
             prev_encrypt_total = current_encrypt_total
             prev_decrypt_total = current_decrypt_total
             prev_auth_total = current_auth_total
+            prev_auth_sign_total = current_auth_sign_total
+            prev_auth_verify_total = current_auth_verify_total
             parallel_factor = max(round_fit_parallel, round_eval_parallel, 1)
             parallel_crypto_time = min(
                 round_crypto_time / parallel_factor, round_elapsed
@@ -238,6 +244,12 @@ class Server:
             parallel_auth_time = min(
                 round_auth_time / parallel_factor, round_elapsed
             )
+            parallel_auth_sign_time = min(
+                round_auth_sign_time / parallel_factor, round_elapsed
+            )
+            parallel_auth_verify_time = min(
+                round_auth_verify_time / parallel_factor, round_elapsed
+            )
             without_crypto = max(round_elapsed - parallel_crypto_time, 0.0)
             log_file.ROUND_SUMMARIES.append({
                 "round": current_round,
@@ -248,6 +260,8 @@ class Server:
                 "decrypt_time": parallel_decrypt_time,
                 "auth_time": parallel_auth_time,
                 "auth_cumulative": round_auth_time,
+                "auth_sign_time": parallel_auth_sign_time,
+                "auth_verify_time": parallel_auth_verify_time,
                 "parallel_fit": float(round_fit_parallel),
                 "parallel_eval": float(round_eval_parallel),
                 "parallel_factor": float(parallel_factor),
@@ -255,11 +269,13 @@ class Server:
             })
 
             log_time(
-                "Tempo totale round %s: %.2f s | cifratura: %.2f s | decifratura: %.2f s",
+                "Tempo totale round %s: %.2f s | cifratura: %.2f s | decifratura: %.2f s | firma: %.2f s | verifica: %.2f s",
                 current_round,
                 round_elapsed,
                 parallel_encrypt_time,
                 parallel_decrypt_time,
+                parallel_auth_sign_time,
+                parallel_auth_verify_time,
             )
 
             history.add_metrics_centralized(


### PR DESCRIPTION
### Motivation
- Fornire metriche separate per tempo di firma e tempo di verifica dell'autenticazione nelle statistiche crypto dei round, così da misurare l'impatto delle operazioni di integrità/firma.

### Description
- Aggiunti contatori globali `TOTAL_AUTH_SIGN_TIME` e `TOTAL_AUTH_VERIFY_TIME` con funzioni di supporto `add_auth_sign_verify_time` e `get_auth_sign_verify_totals` in `framework/py/flwr/common/crypto/log_file.py` e inclusi nei report dei round (mostrati come `firma` e `verifica`).
- Misurato il tempo di verifica (verify) in `arrayrecord_to_parameters` e accumulato in `log_file` come verifica; misurato il tempo di firma (sign) in `parameters_to_arrayrecord` e accumulato come firma in `log_file`, entrambi in `framework/py/flwr/common/recorddict_compat.py`.
- Raccolti i delta per-round di firma/verifica nel server, salvati in `log_file.ROUND_SUMMARIES` e inclusi nel log dei tempi di round; aggiornamenti in `framework/py/flwr/server/server.py` per calcolare i delta e formattare l'output dei tempi di round.

### Testing
- Eseguito compilazione statica dei file modificati con `python -m compileall /workspace/flowerCrypto/framework/py/flwr/common/crypto/log_file.py /workspace/flowerCrypto/framework/py/flwr/common/recorddict_compat.py /workspace/flowerCrypto/framework/py/flwr/server/server.py` e la compilazione è andata a buon fine.
- Tentato `python -m pytest /workspace/flowerCrypto/framework/py/flwr/common/recorddict_compat_test.py -q`, ma la raccolta dei test fallisce in questo ambiente per un conflitto tra `pytest` e il pacchetto locale `py` (`AttributeError: module 'py' has no attribute 'path'`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a6eeaf039883328e283b880644330c)