### PR TITLE
Track integrity and per-sign/verify auth timings and include them in round and run reports

### DIFF
--- a/framework/py/flwr/common/crypto/log_file.py
+++ b/framework/py/flwr/common/crypto/log_file.py
@@ -10,6 +10,9 @@ TOTAL_ENCRYPT_TIME = 0.0
 TOTAL_DECRYPT_TIME = 0.0
 TOTAL_SERIAL_TIME = 0.0
 TOTAL_AUTH_TIME = 0.0
+TOTAL_AUTH_SIGN_TIME = 0.0
+TOTAL_AUTH_VERIFY_TIME = 0.0
+TOTAL_INTEGRITY_TIME = 0.0
 TOTAL_OVERHEAD_BYTES = 0
 TOTAL_PLAINTEXT_BYTES = 0
 OVERHEAD_BY_METHOD: Dict[str, int] = {}
@@ -22,6 +25,8 @@ def reset_crypto_totals() -> None:
     """Reset accumulated crypto/serialization totals."""
     global TOTAL_CRYPTO_TIME, TOTAL_ENCRYPT_TIME, TOTAL_DECRYPT_TIME
     global TOTAL_SERIAL_TIME, TOTAL_AUTH_TIME
+    global TOTAL_AUTH_SIGN_TIME, TOTAL_AUTH_VERIFY_TIME
+    global TOTAL_INTEGRITY_TIME
     global TOTAL_OVERHEAD_BYTES, TOTAL_PLAINTEXT_BYTES
     global OVERHEAD_BY_METHOD, OVERHEAD_COUNT_BY_METHOD
     global OVERHEAD_BY_CATEGORY, OVERHEAD_COUNT_BY_CATEGORY
@@ -30,6 +35,9 @@ def reset_crypto_totals() -> None:
     TOTAL_DECRYPT_TIME = 0.0
     TOTAL_SERIAL_TIME = 0.0
     TOTAL_AUTH_TIME = 0.0
+    TOTAL_AUTH_SIGN_TIME = 0.0
+    TOTAL_AUTH_VERIFY_TIME = 0.0
+    TOTAL_INTEGRITY_TIME = 0.0
     TOTAL_OVERHEAD_BYTES = 0
     TOTAL_PLAINTEXT_BYTES = 0
     OVERHEAD_BY_METHOD = {}
@@ -58,6 +66,20 @@ def add_auth_time(auth_time: float) -> None:
     TOTAL_AUTH_TIME += auth_time
 
 
+def add_auth_sign_verify_time(sign_time: float, verify_time: float) -> None:
+    """Accumulate authentication sign/verify times for summary reporting."""
+    global TOTAL_AUTH_SIGN_TIME, TOTAL_AUTH_VERIFY_TIME
+    TOTAL_AUTH_SIGN_TIME += sign_time
+    TOTAL_AUTH_VERIFY_TIME += verify_time
+
+
+
+
+def add_integrity_time(integrity_time: float) -> None:
+    """Accumulate integrity time for summary reporting."""
+    global TOTAL_INTEGRITY_TIME
+    TOTAL_INTEGRITY_TIME += integrity_time
+
 def get_crypto_totals() -> tuple[float, float]:
     """Return accumulated crypto and serialization totals."""
     return TOTAL_CRYPTO_TIME, TOTAL_SERIAL_TIME
@@ -68,9 +90,20 @@ def get_encrypt_decrypt_totals() -> tuple[float, float]:
     return TOTAL_ENCRYPT_TIME, TOTAL_DECRYPT_TIME
 
 
+
+
+def get_integrity_totals() -> float:
+    """Return accumulated integrity totals."""
+    return TOTAL_INTEGRITY_TIME
+
 def get_auth_totals() -> float:
     """Return accumulated authentication totals."""
     return TOTAL_AUTH_TIME
+
+
+def get_auth_sign_verify_totals() -> tuple[float, float]:
+    """Return accumulated authentication sign/verify totals."""
+    return TOTAL_AUTH_SIGN_TIME, TOTAL_AUTH_VERIFY_TIME
 
 
 def add_overhead(
@@ -202,6 +235,9 @@ def build_round_time_report() -> List[str]:
     total_round_time = 0.0
     total_crypto_time = 0.0
     total_auth_time = 0.0
+    total_integrity_time = 0.0
+    total_auth_sign_time = 0.0
+    total_auth_verify_time = 0.0
     total_crypto_cumulative = 0.0
     total_auth_cumulative = 0.0
 
@@ -212,6 +248,9 @@ def build_round_time_report() -> List[str]:
         decrypt_time = summary.get("decrypt_time", 0.0)
         without_crypto = summary["without_crypto"]
         auth_time = summary.get("auth_time", 0.0)
+        integrity_time = summary.get("integrity_time", 0.0)
+        auth_sign_time = summary.get("auth_sign_time", 0.0)
+        auth_verify_time = summary.get("auth_verify_time", 0.0)
         crypto_cumulative = summary.get("crypto_cumulative", crypto_time)
         auth_cumulative = summary.get("auth_cumulative", auth_time)
         parallel_factor = summary.get("parallel_factor")
@@ -233,8 +272,9 @@ def build_round_time_report() -> List[str]:
         lines.append(
             "Round {round_num}: totale={round_time:.2f}s | "
             "crypto={crypto_time:.2f}s ({impact:.2f}%) | "
-            "encrypt={encrypt_time:.2f}s | decrypt={decrypt_time:.2f}s | "
+            "encrypt={encrypt_time:.2f}s | decrypt={decrypt_time:.2f}s | integrity={integrity_time:.2f}s | "
             "auth={auth_time:.2f}s ({auth_impact:.2f}%) | "
+            "firma={auth_sign_time:.2f}s | verifica={auth_verify_time:.2f}s | "
             "crypto_cum={crypto_cumulative:.2f}s | auth_cum={auth_cumulative:.2f}s | "
             "senza_critto={without_crypto:.2f}s{parallel_note}".format(
                 round_num=int(summary["round"]),
@@ -243,8 +283,11 @@ def build_round_time_report() -> List[str]:
                 impact=impact,
                 encrypt_time=encrypt_time,
                 decrypt_time=decrypt_time,
+                integrity_time=integrity_time,
                 auth_time=auth_time,
                 auth_impact=auth_impact,
+                auth_sign_time=auth_sign_time,
+                auth_verify_time=auth_verify_time,
                 crypto_cumulative=crypto_cumulative,
                 auth_cumulative=auth_cumulative,
                 without_crypto=without_crypto,
@@ -255,6 +298,9 @@ def build_round_time_report() -> List[str]:
         total_round_time += round_time
         total_crypto_time += crypto_time
         total_auth_time += auth_time
+        total_integrity_time += integrity_time
+        total_auth_sign_time += auth_sign_time
+        total_auth_verify_time += auth_verify_time
         total_crypto_cumulative += crypto_cumulative
         total_auth_cumulative += auth_cumulative
 
@@ -277,10 +323,21 @@ def build_round_time_report() -> List[str]:
         )
     )
     lines.append(
+        "Totale integrity (parallel): {total_integrity:.2f}s".format(
+            total_integrity=total_integrity_time,
+        )
+    )
+    lines.append(
         "Totale auth (parallel): {total_auth:.2f}s su {total_round:.2f}s ({impact:.2f}%)".format(
             total_auth=total_auth_time,
             total_round=total_round_time,
             impact=total_auth_impact,
+        )
+    )
+    lines.append(
+        "Totale firma (parallel): {total_sign:.2f}s | totale verifica (parallel): {total_verify:.2f}s".format(
+            total_sign=total_auth_sign_time,
+            total_verify=total_auth_verify_time,
         )
     )
     if total_crypto_cumulative != total_crypto_time:

--- a/framework/py/flwr/common/recorddict_compat.py
+++ b/framework/py/flwr/common/recorddict_compat.py
@@ -72,7 +72,9 @@ def arrayrecord_to_parameters(record: ArrayRecord, keep_input: bool) -> Paramete
     total_deser_time = 0.0   # tempo per costruire gli oggetti Parameters (no decrypt)
     total_crypto_time = 0.0  # tempo crypto (cifratura/integrità)
     total_decrypt_time = 0.0
+    total_integrity_time = 0.0
     total_auth_time = 0.0
+    total_auth_verify_time = 0.0
 
     # Iteriamo direttamente sulle chiavi senza creare copie costose
     for key in list(record.keys()):
@@ -96,13 +98,17 @@ def arrayrecord_to_parameters(record: ArrayRecord, keep_input: bool) -> Paramete
             start_auth = time.perf_counter()
             data = verify_authentication(data, AUTH_METHOD)
             end_auth = time.perf_counter()
-            total_auth_time += (end_auth - start_auth)
+            auth_verify_elapsed = end_auth - start_auth
+            total_auth_time += auth_verify_elapsed
+            total_auth_verify_time += auth_verify_elapsed
 
         if INTEGRITY_ENABLED:
             start_integrity = time.perf_counter()
             data = check_integrity(data, INTEGRITY_METHOD)
             end_integrity = time.perf_counter()
-            total_crypto_time += (end_integrity - start_integrity)
+            integrity_elapsed = end_integrity - start_integrity
+            total_crypto_time += integrity_elapsed
+            total_integrity_time += integrity_elapsed
 
         if ENCRYPTION_ENABLED:
             start_decrypt = time.perf_counter()
@@ -125,7 +131,9 @@ def arrayrecord_to_parameters(record: ArrayRecord, keep_input: bool) -> Paramete
     auth_impact = (total_auth_time / total_time * 100.0) if total_time > 0 else 0.0
     log_file.add_crypto_time(total_crypto_time, total_deser_time)
     log_file.add_encrypt_decrypt_time(0.0, total_decrypt_time)
+    log_file.add_integrity_time(total_integrity_time)
     log_file.add_auth_time(total_auth_time)
+    log_file.add_auth_sign_verify_time(0.0, total_auth_verify_time)
     log_time(
         "CRYPTO STATUS: enabled=%s method=%s | auth_enabled=%s auth_method=%s | "
         "DESERIALIZE: %.5f s | CRYPTO: %.5f s | AUTH: %.5f s | TOTAL: %.5f s | "
@@ -154,7 +162,9 @@ def parameters_to_arrayrecord(parameters: Parameters, keep_input: bool) -> Array
     tot_serial_time = 0.0
     tot_crypto_time = 0.0
     tot_encrypt_time = 0.0
+    tot_integrity_time = 0.0
     tot_auth_time = 0.0
+    tot_auth_sign_time = 0.0
 
     for idx in range(num_arrays):
 
@@ -190,7 +200,9 @@ def parameters_to_arrayrecord(parameters: Parameters, keep_input: bool) -> Array
             start_integrity = time.perf_counter()
             dataR = add_integrity(dataR, INTEGRITY_METHOD)
             end_integrity = time.perf_counter()
-            tot_crypto_time += (end_integrity - start_integrity)
+            integrity_elapsed = end_integrity - start_integrity
+            tot_crypto_time += integrity_elapsed
+            tot_integrity_time += integrity_elapsed
             log_file.add_overhead(
                 INTEGRITY_METHOD,
                 "integrity",
@@ -205,6 +217,7 @@ def parameters_to_arrayrecord(parameters: Parameters, keep_input: bool) -> Array
             end_auth = time.perf_counter()
             auth_elapsed = end_auth - start_auth
             tot_auth_time += auth_elapsed
+            tot_auth_sign_time += auth_elapsed
             log_file.add_overhead(
                 AUTH_METHOD,
                 "auth",
@@ -229,7 +242,9 @@ def parameters_to_arrayrecord(parameters: Parameters, keep_input: bool) -> Array
     auth_impact = (tot_auth_time / total_time * 100.0) if total_time > 0 else 0.0
     log_file.add_crypto_time(tot_crypto_time, tot_serial_time)
     log_file.add_encrypt_decrypt_time(tot_encrypt_time, 0.0)
+    log_file.add_integrity_time(tot_integrity_time)
     log_file.add_auth_time(tot_auth_time)
+    log_file.add_auth_sign_verify_time(tot_auth_sign_time, 0.0)
     log_time(
         "CRYPTO STATUS: enabled=%s method=%s | auth_enabled=%s auth_method=%s | "
         "SERIALIZE: %.5f s | CRYPTO: %.5f s | AUTH: %.5f s | TOTAL: %.5f s | "

--- a/framework/py/flwr/server/server.py
+++ b/framework/py/flwr/server/server.py
@@ -150,7 +150,9 @@ class Server:
         # Run federated learning for num_rounds
         prev_crypto_total, _ = log_file.get_crypto_totals()
         prev_encrypt_total, prev_decrypt_total = log_file.get_encrypt_decrypt_totals()
+        prev_integrity_total = log_file.get_integrity_totals()
         prev_auth_total = log_file.get_auth_totals()
+        prev_auth_sign_total, prev_auth_verify_total = log_file.get_auth_sign_verify_totals()
 
         for current_round in range(1, num_rounds + 1):
             if getattr(self.strategy, "stop_triggered", False):
@@ -216,15 +218,23 @@ class Server:
             round_elapsed = timeit.default_timer() - round_start
             current_crypto_total, _ = log_file.get_crypto_totals()
             current_encrypt_total, current_decrypt_total = log_file.get_encrypt_decrypt_totals()
+            current_integrity_total = log_file.get_integrity_totals()
             current_auth_total = log_file.get_auth_totals()
+            current_auth_sign_total, current_auth_verify_total = log_file.get_auth_sign_verify_totals()
             round_crypto_time = max(current_crypto_total - prev_crypto_total, 0.0)
             round_encrypt_time = max(current_encrypt_total - prev_encrypt_total, 0.0)
             round_decrypt_time = max(current_decrypt_total - prev_decrypt_total, 0.0)
+            round_integrity_time = max(current_integrity_total - prev_integrity_total, 0.0)
             round_auth_time = max(current_auth_total - prev_auth_total, 0.0)
+            round_auth_sign_time = max(current_auth_sign_total - prev_auth_sign_total, 0.0)
+            round_auth_verify_time = max(current_auth_verify_total - prev_auth_verify_total, 0.0)
             prev_crypto_total = current_crypto_total
             prev_encrypt_total = current_encrypt_total
             prev_decrypt_total = current_decrypt_total
+            prev_integrity_total = current_integrity_total
             prev_auth_total = current_auth_total
+            prev_auth_sign_total = current_auth_sign_total
+            prev_auth_verify_total = current_auth_verify_total
             parallel_factor = max(round_fit_parallel, round_eval_parallel, 1)
             parallel_crypto_time = min(
                 round_crypto_time / parallel_factor, round_elapsed
@@ -235,8 +245,17 @@ class Server:
             parallel_decrypt_time = min(
                 round_decrypt_time / parallel_factor, round_elapsed
             )
+            parallel_integrity_time = min(
+                round_integrity_time / parallel_factor, round_elapsed
+            )
             parallel_auth_time = min(
                 round_auth_time / parallel_factor, round_elapsed
+            )
+            parallel_auth_sign_time = min(
+                round_auth_sign_time / parallel_factor, round_elapsed
+            )
+            parallel_auth_verify_time = min(
+                round_auth_verify_time / parallel_factor, round_elapsed
             )
             without_crypto = max(round_elapsed - parallel_crypto_time, 0.0)
             log_file.ROUND_SUMMARIES.append({
@@ -246,8 +265,11 @@ class Server:
                 "crypto_cumulative": round_crypto_time,
                 "encrypt_time": parallel_encrypt_time,
                 "decrypt_time": parallel_decrypt_time,
+                "integrity_time": parallel_integrity_time,
                 "auth_time": parallel_auth_time,
                 "auth_cumulative": round_auth_time,
+                "auth_sign_time": parallel_auth_sign_time,
+                "auth_verify_time": parallel_auth_verify_time,
                 "parallel_fit": float(round_fit_parallel),
                 "parallel_eval": float(round_eval_parallel),
                 "parallel_factor": float(parallel_factor),
@@ -255,11 +277,14 @@ class Server:
             })
 
             log_time(
-                "Tempo totale round %s: %.2f s | cifratura: %.2f s | decifratura: %.2f s",
+                "Tempo totale round %s: %.2f s | cifratura: %.2f s | decifratura: %.2f s | integrity: %.2f s | firma: %.2f s | verifica: %.2f s",
                 current_round,
                 round_elapsed,
                 parallel_encrypt_time,
                 parallel_decrypt_time,
+                parallel_integrity_time,
+                parallel_auth_sign_time,
+                parallel_auth_verify_time,
             )
 
             history.add_metrics_centralized(
@@ -646,24 +671,72 @@ def run_fl(
 
     log(INFO, "")
     log(INFO, "[SUMMARY]")
-    log(INFO, "Run finished %s round(s) in %.2fs", config.num_rounds, elapsed_time)
-    log_time("Run finished %s round(s) in %.2fs", config.num_rounds, elapsed_time)
-    total_crypto_time, total_serial_time = log_file.get_crypto_totals()
-    total_auth_time = log_file.get_auth_totals()
+    executed_rounds = len(hist.metrics_centralized.get("round_time", []))
+    if executed_rounds == 0:
+        executed_rounds = len(hist.losses_centralized)
+    if executed_rounds == 0:
+        executed_rounds = config.num_rounds
+
+    log(INFO, "Run finished %s round(s) in %.2fs", executed_rounds, elapsed_time)
+    log_time(
+        "Run finished %s round(s) in %.2fs (tempo wall-clock totale, include training+rete+auth/crypto)",
+        executed_rounds,
+        elapsed_time,
+    )
+    total_crypto_time_cumulative, total_serial_time = log_file.get_crypto_totals()
+    total_integrity_time = log_file.get_integrity_totals()
+    total_auth_time_cumulative = log_file.get_auth_totals()
+    total_auth_sign_time_cumulative, total_auth_verify_time_cumulative = log_file.get_auth_sign_verify_totals()
+
+    round_summaries = log_file.get_round_summaries()
+    total_crypto_time_parallel = sum(s.get("crypto_time", 0.0) for s in round_summaries)
+    total_encrypt_time_parallel = sum(s.get("encrypt_time", 0.0) for s in round_summaries)
+    total_decrypt_time_parallel = sum(s.get("decrypt_time", 0.0) for s in round_summaries)
+    total_integrity_time_parallel = sum(s.get("integrity_time", 0.0) for s in round_summaries)
+    total_auth_time_parallel = sum(s.get("auth_time", 0.0) for s in round_summaries)
+    total_auth_sign_time_parallel = sum(s.get("auth_sign_time", 0.0) for s in round_summaries)
+    total_auth_verify_time_parallel = sum(s.get("auth_verify_time", 0.0) for s in round_summaries)
+
     crypto_impact = (
-        (total_crypto_time / elapsed_time * 100.0) if elapsed_time > 0 else 0.0
+        (total_crypto_time_parallel / elapsed_time * 100.0) if elapsed_time > 0 else 0.0
     )
     auth_impact = (
-        (total_auth_time / elapsed_time * 100.0) if elapsed_time > 0 else 0.0
+        (total_auth_time_parallel / elapsed_time * 100.0) if elapsed_time > 0 else 0.0
     )
     log_time(
-        "Totale critto: %.2f s su %.2f s (%.2f%%) | auth: %.2f s (%.2f%%) | serializzazione: %.2f s",
-        total_crypto_time,
+        "Totale critto (parallel): %.2f s su %.2f s (%.2f%%) | encrypt: %.2f s | decrypt: %.2f s | integrity: %.2f s | auth: %.2f s (%.2f%%) | firma: %.2f s | verifica: %.2f s | serializzazione: %.2f s",
+        total_crypto_time_parallel,
         elapsed_time,
         crypto_impact,
-        total_auth_time,
+        total_encrypt_time_parallel,
+        total_decrypt_time_parallel,
+        total_integrity_time_parallel,
+        total_auth_time_parallel,
         auth_impact,
+        total_auth_sign_time_parallel,
+        total_auth_verify_time_parallel,
         total_serial_time,
+    )
+    log_time(
+        "Totale critto cumulativo (somma operazioni su tutti i client): %.2f s | auth cumulativo: %.2f s | integrity cumulativo: %.2f s",
+        total_crypto_time_cumulative,
+        total_auth_time_cumulative,
+        total_integrity_time,
+    )
+    estimated_without_auth_parallel = max(elapsed_time - total_auth_time_parallel, 0.0)
+    estimated_without_crypto_auth_parallel = max(
+        elapsed_time - total_auth_time_parallel - total_crypto_time_parallel,
+        0.0,
+    )
+    log_time(
+        "Tempo totale include auth/crypto. Stima senza auth (parallel): %.2f s | senza auth+crypto (parallel): %.2f s",
+        estimated_without_auth_parallel,
+        estimated_without_crypto_auth_parallel,
+    )
+    log_time(
+        "Totale firma cumulativo: %.2f s | totale verifica cumulativo: %.2f s",
+        total_auth_sign_time_cumulative,
+        total_auth_verify_time_cumulative,
     )
     for line in log_file.build_overhead_report():
         log_time(line)


### PR DESCRIPTION
### Motivation
- Add finer-grained timing and overhead metrics for integrity checks and authentication split into signing and verification to better measure crypto/auth impact per-round and for the whole run.
- Surface these new metrics in per-round summaries and final run reports to allow more accurate accounting of parallel vs cumulative crypto/auth costs.

### Description
- Introduce new global counters in `log_file.py`: `TOTAL_AUTH_SIGN_TIME`, `TOTAL_AUTH_VERIFY_TIME`, and `TOTAL_INTEGRITY_TIME` with corresponding `add_` and `get_` accessor functions (`add_auth_sign_verify_time`, `add_integrity_time`, `get_auth_sign_verify_totals`, `get_integrity_totals`).
- Extend round reporting in `log_file.build_round_time_report()` to include `integrity`, `firma` (sign) and `verifica` (verify) times and aggregate totals for those metrics.
- Update `recorddict_compat.py` to measure integrity and auth sign/verify durations in both `arrayrecord_to_parameters` and `parameters_to_arrayrecord`, update accumulation logic, and report these timings to `log_file` via the new APIs.
- Modify `server.py` to snapshot and delta the new integrity and auth sign/verify totals each round, include them in `ROUND_SUMMARIES`, compute parallelized times, and expand per-round and final run logging to report parallel and cumulative `encrypt`, `decrypt`, `integrity`, `auth`, `sign`, and `verify` metrics; also improve determination of executed rounds for final reporting.

### Testing
- No automated tests were added or executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a6eeaf039883328e283b880644330c)