### PR TITLE
Handle out-of-order object pushes under high concurrency

### DIFF
--- a/framework/py/flwr/server/superlink/fleet/grpc_rere/fleet_servicer_test.py
+++ b/framework/py/flwr/server/superlink/fleet/grpc_rere/fleet_servicer_test.py
@@ -411,7 +411,7 @@ class TestFleetServicer(unittest.TestCase):  # pylint: disable=R0902
         obj = ConfigRecord({"a": 123, "b": [4, 5, 6]})
         obj_b = obj.deflate()
 
-        # Push valid object but it hasn't been pre-registered
+        # Push valid object without pre-registration
         req = PushObjectRequest(
             node=Node(node_id=node_id),
             run_id=run_id,
@@ -420,8 +420,8 @@ class TestFleetServicer(unittest.TestCase):  # pylint: disable=R0902
         )
         res: PushObjectResponse = self._push_object(request=req)
 
-        # Assert: object not inserted
-        assert not res.stored
+        # Assert: object inserted via fallback pre-registration
+        assert res.stored
 
         # Push valid object but its hash doesnt match the one passed in the request
         # Preregister under a different object-id

--- a/framework/py/flwr/server/superlink/fleet/message_handler/message_handler.py
+++ b/framework/py/flwr/server/superlink/fleet/message_handler/message_handler.py
@@ -19,7 +19,10 @@ from typing import Optional
 
 from flwr.common import Message, log
 from flwr.common.constant import Status
-from flwr.common.inflatable import UnexpectedObjectContentError
+from flwr.common.inflatable import (
+    UnexpectedObjectContentError,
+    get_object_children_ids_from_object_content,
+)
 from flwr.common.serde import (
     fab_to_proto,
     message_from_proto,
@@ -46,6 +49,7 @@ from flwr.proto.heartbeat_pb2 import (  # pylint: disable=E0611
 from flwr.proto.message_pb2 import (  # pylint: disable=E0611
     ConfirmMessageReceivedRequest,
     ConfirmMessageReceivedResponse,
+    ObjectTree,
     PullObjectRequest,
     PullObjectResponse,
     PushObjectRequest,
@@ -231,7 +235,24 @@ def push_object(
     try:
         store.put(request.object_id, request.object_content)
         stored = True
-    except (NoObjectInStoreError, ValueError) as e:
+    except NoObjectInStoreError:
+        # Fallback for out-of-order delivery under high concurrency.
+        object_tree = ObjectTree(
+            object_id=request.object_id,
+            children=[
+                ObjectTree(object_id=child_id)
+                for child_id in get_object_children_ids_from_object_content(
+                    request.object_content
+                )
+            ],
+        )
+        try:
+            store.preregister(request.run_id, object_tree)
+            store.put(request.object_id, request.object_content)
+            stored = True
+        except (NoObjectInStoreError, ValueError) as e:
+            log(ERROR, str(e))
+    except ValueError as e:
         log(ERROR, str(e))
     except UnexpectedObjectContentError as e:
         # Object content is not valid

--- a/framework/py/flwr/server/superlink/serverappio/serverappio_servicer.py
+++ b/framework/py/flwr/server/superlink/serverappio/serverappio_servicer.py
@@ -26,6 +26,7 @@ from flwr.common.constant import SUPERLINK_NODE_ID, Status
 from flwr.common.inflatable import (
     UnexpectedObjectContentError,
     get_all_nested_objects,
+    get_object_children_ids_from_object_content,
     get_object_tree,
     no_object_id_recompute,
 )
@@ -68,6 +69,7 @@ from flwr.proto.log_pb2 import (  # pylint: disable=E0611
 from flwr.proto.message_pb2 import (  # pylint: disable=E0611
     ConfirmMessageReceivedRequest,
     ConfirmMessageReceivedResponse,
+    ObjectTree,
     PullObjectRequest,
     PullObjectResponse,
     PushObjectRequest,
@@ -485,7 +487,24 @@ class ServerAppIoServicer(serverappio_pb2_grpc.ServerAppIoServicer):
         try:
             store.put(request.object_id, request.object_content)
             stored = True
-        except (NoObjectInStoreError, ValueError) as e:
+        except NoObjectInStoreError:
+            # Fallback for out-of-order delivery under high concurrency.
+            object_tree = ObjectTree(
+                object_id=request.object_id,
+                children=[
+                    ObjectTree(object_id=child_id)
+                    for child_id in get_object_children_ids_from_object_content(
+                        request.object_content
+                    )
+                ],
+            )
+            try:
+                store.preregister(request.run_id, object_tree)
+                store.put(request.object_id, request.object_content)
+                stored = True
+            except (NoObjectInStoreError, ValueError) as e:
+                log(ERROR, str(e))
+        except ValueError as e:
             log(ERROR, str(e))
         except UnexpectedObjectContentError as e:
             # Object content is not valid

--- a/framework/py/flwr/server/superlink/serverappio/serverappio_servicer_test.py
+++ b/framework/py/flwr/server/superlink/serverappio/serverappio_servicer_test.py
@@ -745,7 +745,7 @@ class TestServerAppIoServicer(unittest.TestCase):  # pylint: disable=R0902, R090
         obj = ConfigRecord({"a": 123, "b": [4, 5, 6]})
         obj_b = obj.deflate()
 
-        # Push valid object but it hasn't been pre-registered
+        # Push valid object without pre-registration
         req = PushObjectRequest(
             node=Node(node_id=SUPERLINK_NODE_ID),
             run_id=run_id,
@@ -754,8 +754,8 @@ class TestServerAppIoServicer(unittest.TestCase):  # pylint: disable=R0902, R090
         )
         res: PushObjectResponse = self._push_object(request=req)
 
-        # Assert: object not inserted
-        assert not res.stored
+        # Assert: object inserted via fallback pre-registration
+        assert res.stored
 
         # Push valid object but its hash doesnt match the one passed in the request
         # Preregister under a different object-id


### PR DESCRIPTION
### Motivation
- Avoid noisy "Object with ID ... was not pre-registered" errors and dropped uploads when object content arrives before message-tree preregistration under high concurrency.

### Description
- Add a fallback in Fleet `push_object` to parse direct child IDs from the incoming object header with `get_object_children_ids_from_object_content`, build a minimal `ObjectTree`, call `store.preregister(...)`, and retry `store.put(...)` when `NoObjectInStoreError` occurs.
- Apply the same fallback in `ServerAppIoServicer.PushObject` to keep behavior consistent across SuperLink endpoints. 
- Update imports to include `get_object_children_ids_from_object_content` and `ObjectTree`, and update tests to expect `stored=True` for valid objects that arrive without prior preregistration while preserving the previous failure semantics for hash/content mismatches. 
- Modified files: `framework/py/flwr/server/superlink/fleet/message_handler/message_handler.py`, `framework/py/flwr/server/superlink/serverappio/serverappio_servicer.py`, and updated tests `framework/py/flwr/server/superlink/fleet/grpc_rere/fleet_servicer_test.py` and `framework/py/flwr/server/superlink/serverappio/serverappio_servicer_test.py`.

### Testing
- Successfully compiled the modified modules with `python -m compileall <files>` and verification completed without syntax errors. 
- Attempted targeted test runs with `python -m pytest ... -k push_object` and `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python -m pytest ...`, but test execution in this container was blocked by local pytest/import environment issues (pytest plugin and `py` module shadowing), preventing full automated test execution here. 
- Updated unit tests in the repository to reflect the new expected behavior for out-of-order valid object pushes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c3ba4f83348332b3d044220c4e818d)