### PR TITLE
Handle out-of-order object delivery by auto-preregistering and lazily creating child placeholders

### DIFF
--- a/framework/py/flwr/server/superlink/fleet/grpc_rere/fleet_servicer_test.py
+++ b/framework/py/flwr/server/superlink/fleet/grpc_rere/fleet_servicer_test.py
@@ -411,7 +411,7 @@ class TestFleetServicer(unittest.TestCase):  # pylint: disable=R0902
         obj = ConfigRecord({"a": 123, "b": [4, 5, 6]})
         obj_b = obj.deflate()
 
-        # Push valid object but it hasn't been pre-registered
+        # Push valid object without pre-registration
         req = PushObjectRequest(
             node=Node(node_id=node_id),
             run_id=run_id,
@@ -420,8 +420,8 @@ class TestFleetServicer(unittest.TestCase):  # pylint: disable=R0902
         )
         res: PushObjectResponse = self._push_object(request=req)
 
-        # Assert: object not inserted
-        assert not res.stored
+        # Assert: object inserted via fallback pre-registration
+        assert res.stored
 
         # Push valid object but its hash doesnt match the one passed in the request
         # Preregister under a different object-id

--- a/framework/py/flwr/server/superlink/fleet/message_handler/message_handler.py
+++ b/framework/py/flwr/server/superlink/fleet/message_handler/message_handler.py
@@ -19,7 +19,10 @@ from typing import Optional
 
 from flwr.common import Message, log
 from flwr.common.constant import Status
-from flwr.common.inflatable import UnexpectedObjectContentError
+from flwr.common.inflatable import (
+    UnexpectedObjectContentError,
+    get_object_children_ids_from_object_content,
+)
 from flwr.common.serde import (
     fab_to_proto,
     message_from_proto,
@@ -46,6 +49,7 @@ from flwr.proto.heartbeat_pb2 import (  # pylint: disable=E0611
 from flwr.proto.message_pb2 import (  # pylint: disable=E0611
     ConfirmMessageReceivedRequest,
     ConfirmMessageReceivedResponse,
+    ObjectTree,
     PullObjectRequest,
     PullObjectResponse,
     PushObjectRequest,
@@ -231,7 +235,24 @@ def push_object(
     try:
         store.put(request.object_id, request.object_content)
         stored = True
-    except (NoObjectInStoreError, ValueError) as e:
+    except NoObjectInStoreError:
+        # Fallback for out-of-order delivery under high concurrency.
+        object_tree = ObjectTree(
+            object_id=request.object_id,
+            children=[
+                ObjectTree(object_id=child_id)
+                for child_id in get_object_children_ids_from_object_content(
+                    request.object_content
+                )
+            ],
+        )
+        try:
+            store.preregister(request.run_id, object_tree)
+            store.put(request.object_id, request.object_content)
+            stored = True
+        except (NoObjectInStoreError, ValueError) as e:
+            log(ERROR, str(e))
+    except ValueError as e:
         log(ERROR, str(e))
     except UnexpectedObjectContentError as e:
         # Object content is not valid

--- a/framework/py/flwr/server/superlink/serverappio/serverappio_servicer.py
+++ b/framework/py/flwr/server/superlink/serverappio/serverappio_servicer.py
@@ -26,6 +26,7 @@ from flwr.common.constant import SUPERLINK_NODE_ID, Status
 from flwr.common.inflatable import (
     UnexpectedObjectContentError,
     get_all_nested_objects,
+    get_object_children_ids_from_object_content,
     get_object_tree,
     no_object_id_recompute,
 )
@@ -68,6 +69,7 @@ from flwr.proto.log_pb2 import (  # pylint: disable=E0611
 from flwr.proto.message_pb2 import (  # pylint: disable=E0611
     ConfirmMessageReceivedRequest,
     ConfirmMessageReceivedResponse,
+    ObjectTree,
     PullObjectRequest,
     PullObjectResponse,
     PushObjectRequest,
@@ -485,7 +487,24 @@ class ServerAppIoServicer(serverappio_pb2_grpc.ServerAppIoServicer):
         try:
             store.put(request.object_id, request.object_content)
             stored = True
-        except (NoObjectInStoreError, ValueError) as e:
+        except NoObjectInStoreError:
+            # Fallback for out-of-order delivery under high concurrency.
+            object_tree = ObjectTree(
+                object_id=request.object_id,
+                children=[
+                    ObjectTree(object_id=child_id)
+                    for child_id in get_object_children_ids_from_object_content(
+                        request.object_content
+                    )
+                ],
+            )
+            try:
+                store.preregister(request.run_id, object_tree)
+                store.put(request.object_id, request.object_content)
+                stored = True
+            except (NoObjectInStoreError, ValueError) as e:
+                log(ERROR, str(e))
+        except ValueError as e:
             log(ERROR, str(e))
         except UnexpectedObjectContentError as e:
             # Object content is not valid

--- a/framework/py/flwr/server/superlink/serverappio/serverappio_servicer_test.py
+++ b/framework/py/flwr/server/superlink/serverappio/serverappio_servicer_test.py
@@ -745,7 +745,7 @@ class TestServerAppIoServicer(unittest.TestCase):  # pylint: disable=R0902, R090
         obj = ConfigRecord({"a": 123, "b": [4, 5, 6]})
         obj_b = obj.deflate()
 
-        # Push valid object but it hasn't been pre-registered
+        # Push valid object without pre-registration
         req = PushObjectRequest(
             node=Node(node_id=SUPERLINK_NODE_ID),
             run_id=run_id,
@@ -754,8 +754,8 @@ class TestServerAppIoServicer(unittest.TestCase):  # pylint: disable=R0902, R090
         )
         res: PushObjectResponse = self._push_object(request=req)
 
-        # Assert: object not inserted
-        assert not res.stored
+        # Assert: object inserted via fallback pre-registration
+        assert res.stored
 
         # Push valid object but its hash doesnt match the one passed in the request
         # Preregister under a different object-id

--- a/framework/py/flwr/supercore/object_store/in_memory_object_store.py
+++ b/framework/py/flwr/supercore/object_store/in_memory_object_store.py
@@ -21,6 +21,7 @@ from typing import Optional
 
 from flwr.common.inflatable import (
     get_object_id,
+    get_object_children_ids_from_object_content,
     is_valid_sha256_hash,
     iterate_object_tree,
 )
@@ -142,12 +143,31 @@ class InMemoryObjectStore(ObjectStore):
             # Validate object content
             validate_object_content(content=object_content)
 
+        child_object_ids = get_object_children_ids_from_object_content(object_content)
+
         with self.lock_store:
-            # Only allow adding the object if it has been preregistered
+            # If the object was not preregistered (e.g. out-of-order delivery),
+            # lazily register it together with placeholder entries for direct
+            # children inferred from object content.
             if object_id not in self.store:
-                raise NoObjectInStoreError(
-                    f"Object with ID '{object_id}' was not pre-registered."
+                self.store[object_id] = ObjectEntry(
+                    content=object_content,
+                    is_available=True,
+                    child_object_ids=child_object_ids,
+                    ref_count=0,
+                    runs=set(),
                 )
+                for child_id in child_object_ids:
+                    if child_id not in self.store:
+                        self.store[child_id] = ObjectEntry(
+                            content=b"",
+                            is_available=False,
+                            child_object_ids=[],
+                            ref_count=0,
+                            runs=set(),
+                        )
+                    self.store[child_id].ref_count += 1
+                return
 
             # Return if object is already present in the store
             if self.store[object_id].is_available:

--- a/framework/py/flwr/supercore/object_store/object_store_test.py
+++ b/framework/py/flwr/supercore/object_store/object_store_test.py
@@ -25,7 +25,7 @@ from flwr.common.inflatable_test import CustomDataClass
 from flwr.proto.message_pb2 import ObjectTree  # pylint: disable=E0611
 
 from .in_memory_object_store import InMemoryObjectStore
-from .object_store import NoObjectInStoreError, ObjectStore
+from .object_store import ObjectStore
 
 
 class ObjectStoreTest(unittest.TestCase):
@@ -190,8 +190,10 @@ class ObjectStoreTest(unittest.TestCase):
         object_id = get_object_id(object_content)
 
         # Execute
-        with self.assertRaises(NoObjectInStoreError):
-            object_store.put(object_id, object_content)
+        object_store.put(object_id, object_content)
+
+        # Assert
+        self.assertEqual(object_store.get(object_id), object_content)
 
     def test_preregister(self) -> None:
         """Test preregister functionality."""


### PR DESCRIPTION
### Motivation

- Allow object uploads that arrive before their preregistration under high concurrency by providing a fallback preregistration path instead of failing with `NoObjectInStoreError`.
- Make the in-memory `ObjectStore` resilient to out-of-order deliveries by lazily registering children inferred from the object content.

### Description

- Added fallback preregistration in `push_object` handlers so that on `NoObjectInStoreError` the code builds an `ObjectTree` from `get_object_children_ids_from_object_content` and calls `store.preregister(...)` before retrying `store.put(...)` in both fleet and serverappio handlers.
- Extended imports to use `get_object_children_ids_from_object_content` and `ObjectTree` where necessary and added logging of errors on failure paths.
- Updated `InMemoryObjectStore.put` to accept un-preregistered objects by computing `child_object_ids` with `get_object_children_ids_from_object_content`, inserting the object entry, creating placeholder entries for direct children, and updating child `ref_count`s.
- Adjusted unit tests to reflect the new behavior by expecting a successful `put`/`PushObject` when preregistration is missing and verifying the object is stored.

### Testing

- Ran updated unit tests for the object store and servicers, including `object_store_test.py`, `serverappio_servicer_test.py`, and `fleet_servicer_test.py`, and observed that tests expecting fallback preregistration now pass.
- Verified `InMemoryObjectStore` tests for `put` without preregistration succeed and that `get` returns the inserted content.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c3ba4f83348332b3d044220c4e818d)